### PR TITLE
Add multi-raft with manual range splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tracing",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 > **Experimental / AI-generated** — This project is a learning exercise built almost entirely with [Claude Code](https://claude.ai/claude-code). It is not production software. Architecture decisions, code quality, and completeness reflect an iterative AI-assisted design process rather than a hardened engineering effort.
 
-A CP-by-default distributed key-value store in pure Rust, with a gRPC interface and Raft consensus. Named after the primordial Norse void from which order emerges.
+A CP-by-default distributed key-value store in pure Rust, with a gRPC interface, Raft consensus, and multi-raft range sharding. Named after the primordial Norse void from which order emerges.
 
 ## Goals
 
 - **CP by default** — Raft consensus guarantees linearizable reads and writes
 - **Configurable consistency** — per-request read mode (`linearizable` / `sequential` / `eventual`) and write quorum (`majority` / `all`)
+- **Multi-raft sharding** — independent Raft group per shard with manual range splitting
 - **MVCC** — per-key version history with configurable depth and point-in-time reads
 - **Pure Rust** — no C FFI; `fjall` for storage instead of RocksDB
 
@@ -28,24 +29,48 @@ A CP-by-default distributed key-value store in pure Rust, with a gRPC interface 
 crates/
 ├── ggap-proto/       # build.rs + generated tonic/prost code
 ├── ggap-types/       # domain types, KvCommand, GgapError — no gRPC dep
-├── ggap-storage/     # LogStorage + StateMachineStore traits + fjall impls
-├── ggap-consensus/   # openraft TypeConfig, RaftNetwork, RaftNode facade
-├── ggap-server/      # tonic service impls, serve_client / serve_cluster
-└── ggap-node/        # binary: CLI, config loading, startup/shutdown
+├── ggap-storage/     # LogStorage + StateMachineStore traits, fjall impls, ShardMap
+├── ggap-consensus/   # openraft TypeConfig, RaftNetwork, ShardRouter, SplitCoordinator
+├── ggap-server/      # tonic service impls (KvService, RaftService, AdminService)
+└── ggap-node/        # binary: CLI, config loading, multi-shard startup/shutdown
 ```
 
 ## Status
 
 | Phase | Description | Status |
 |---|---|---|
-| 1 | Skeleton — workspace, protos, domain types, CLI + config | ✅ Done |
-| 2 | gRPC layer — KvService wired to StubRaftNode; server reflection | ✅ Done |
-| 3 | Storage — `MemLogStorage` / `MemStateMachine`, then `Fjall*` impls | Pending |
-| 4 | Consensus — real `RaftNode`; swap out `StubRaftNode` | Pending |
+| 1 | Skeleton — workspace, protos, domain types, CLI + config | Done |
+| 2 | gRPC layer — KvService, RaftService, AdminService with server reflection | Done |
+| 3 | Storage — `MemLogStorage` / `MemStateMachine`, then `Fjall*` impls | Done |
+| 4 | Consensus — real `OpenRaftNode`; swap out `StubRaftNode` | Done |
 | 5 | Advanced — Watch, MVCC reads, snapshots, TTL GC | Pending |
 | 6 | Hardening — chaos tests, metrics, TLS, tracing | Pending |
+| 7 | Multi-raft — shard routing, manual range splitting | Done |
 
-Multi-raft (Phase 7) is explicitly deferred. The storage key layout and `RaftNode` type already carry a `ShardId` so it remains an additive change when the time comes.
+## Multi-Raft Architecture
+
+Each shard is an independent Raft group with its own log, state machine, and leader election. Key components:
+
+- **ShardMap** — persistent shard-to-key-range mapping stored in fjall. Loaded into an in-memory `BTreeMap` on startup.
+- **ShardRouter** — routes `key -> ShardId -> RaftNode` for reads/writes. Blocks writes to shards in `Splitting` state. Rejects scans that span multiple shards.
+- **SplitCoordinator** — executes a 9-step split protocol that blocks writes on the source shard during the split to guarantee consistency:
+  1. Validate the split request
+  2. Mark source shard as `Splitting`
+  3. Write barrier (linearizable no-op)
+  4. Build partial snapshot of keys >= split_key
+  5. Allocate new shard ID
+  6. Install partial snapshot on new shard
+  7. Delete transferred keys from source
+  8. Update ShardMap with new ranges
+  9. Bootstrap new Raft group and resume writes
+
+All storage keys are prefixed with `be_u64(shard_id)`, so splitting is a metadata + data copy operation with no key re-encoding.
+
+### Limitations
+
+- **Manual splits only** — no automatic load-based or size-based splitting
+- **Single-shard scans** — scans that span shard boundaries are rejected; clients must issue per-shard scans
+- **Writes blocked during split** — the source shard is unavailable for writes while the split executes
 
 ## Running
 
@@ -71,9 +96,29 @@ grpcurl -plaintext \
 grpcurl -plaintext \
   -d '{"key":"hello"}' \
   localhost:17000 ginnungagap.v1.KvService/Get
+
+# Split shard 0 at key "m"
+grpcurl -plaintext \
+  -d '{"shard_id":0,"split_key":"m"}' \
+  localhost:17001 ginnungagap.v1.AdminService/SplitShard
+
+# List all shards
+grpcurl -plaintext \
+  localhost:17001 ginnungagap.v1.AdminService/ListShards
 ```
 
 > Note: ports 7000/7001 conflict with a macOS system service; use 17000/17001.
+
+## Testing
+
+```bash
+cargo test --workspace    # 45 tests across all crates
+```
+
+Key test suites:
+- `ggap-storage` — 35 unit tests covering log storage, state machine, snapshots, key encoding, and shard map
+- `ggap-consensus` — single-node Raft smoke test
+- `ggap-server` — 3-node cluster integration (leader election, failover) and single-node split tests (data partitioning, post-split routing, cascading splits)
 
 ## Configuration
 
@@ -81,7 +126,7 @@ Configuration is layered: embedded defaults → TOML file → `GINNUNGAGAP_*` en
 
 ## CI
 
-The repository uses a GitHub Actions pipeline that runs `cargo check`, `cargo clippy`, and `cargo test` on every pull request.
+GitHub Actions runs `cargo fmt --check`, `cargo clippy`, and `cargo test` on every pull request.
 
 ## License
 

--- a/crates/ggap-consensus/Cargo.toml
+++ b/crates/ggap-consensus/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true }
 bincode = { workspace = true }
 tonic = { workspace = true }
 anyhow = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/crates/ggap-consensus/src/lib.rs
+++ b/crates/ggap-consensus/src/lib.rs
@@ -24,7 +24,7 @@ pub use log_store::GgapLogStorage;
 pub use network::{GgapNetwork, GgapNetworkFactory};
 pub use node::{ClusterNode, GgapRaft, LeaseManager, OpenRaftCluster, OpenRaftNode};
 pub use router::ShardRouter;
-pub use split::SplitCoordinator;
+pub use split::{SplitCoordinator, SplitCoordinatorConfig};
 pub use state_machine::{GgapSnapshotBuilder, GgapStateMachine};
 
 // ---------------------------------------------------------------------------

--- a/crates/ggap-consensus/src/lib.rs
+++ b/crates/ggap-consensus/src/lib.rs
@@ -3,6 +3,8 @@ pub mod convert;
 pub mod log_store;
 pub mod network;
 pub mod node;
+pub mod router;
+pub mod split;
 pub mod state_machine;
 
 use std::collections::BTreeMap;
@@ -21,6 +23,8 @@ pub use config::{build_raft_config, GgapTypeConfig};
 pub use log_store::GgapLogStorage;
 pub use network::{GgapNetwork, GgapNetworkFactory};
 pub use node::{ClusterNode, GgapRaft, LeaseManager, OpenRaftCluster, OpenRaftNode};
+pub use router::ShardRouter;
+pub use split::SplitCoordinator;
 pub use state_machine::{GgapSnapshotBuilder, GgapStateMachine};
 
 // ---------------------------------------------------------------------------

--- a/crates/ggap-consensus/src/network.rs
+++ b/crates/ggap-consensus/src/network.rs
@@ -1,5 +1,5 @@
 use ggap_proto::v1::{raft_service_client::RaftServiceClient, RaftMessage};
-use ggap_types::GgapError;
+use ggap_types::{GgapError, ShardId};
 use openraft::{
     error::{NetworkError, RPCError, RaftError, Unreachable},
     network::RPCOption,
@@ -15,7 +15,15 @@ use crate::convert::{decode, encode};
 // GgapNetworkFactory
 // ---------------------------------------------------------------------------
 
-pub struct GgapNetworkFactory;
+pub struct GgapNetworkFactory {
+    pub shard_id: ShardId,
+}
+
+impl GgapNetworkFactory {
+    pub fn new(shard_id: ShardId) -> Self {
+        GgapNetworkFactory { shard_id }
+    }
+}
 
 impl RaftNetworkFactory<GgapTypeConfig> for GgapNetworkFactory {
     type Network = GgapNetwork;
@@ -24,6 +32,7 @@ impl RaftNetworkFactory<GgapTypeConfig> for GgapNetworkFactory {
         GgapNetwork {
             addr: node.addr.clone(),
             channel: None,
+            shard_id: self.shard_id,
         }
     }
 }
@@ -35,6 +44,7 @@ impl RaftNetworkFactory<GgapTypeConfig> for GgapNetworkFactory {
 pub struct GgapNetwork {
     addr: String,
     channel: Option<RaftServiceClient<Channel>>,
+    shard_id: ShardId,
 }
 
 impl GgapNetwork {
@@ -85,7 +95,10 @@ impl RaftNetwork<GgapTypeConfig> for GgapNetwork {
         let client = self.channel.as_mut().unwrap();
 
         let resp = client
-            .append_entries(RaftMessage { data: payload })
+            .append_entries(RaftMessage {
+                shard_id: self.shard_id,
+                data: payload,
+            })
             .await
             .map_err(Self::to_unreachable)?
             .into_inner();
@@ -104,7 +117,10 @@ impl RaftNetwork<GgapTypeConfig> for GgapNetwork {
         let client = self.channel.as_mut().unwrap();
 
         let resp = client
-            .vote(RaftMessage { data: payload })
+            .vote(RaftMessage {
+                shard_id: self.shard_id,
+                data: payload,
+            })
             .await
             .map_err(Self::to_unreachable)?
             .into_inner();
@@ -121,7 +137,10 @@ impl RaftNetwork<GgapTypeConfig> for GgapNetwork {
         RPCError<u64, BasicNode, RaftError<u64, openraft::error::InstallSnapshotError>>,
     > {
         let payload = encode(&rpc).map_err(Self::to_iss_net_err)?;
-        let msgs = vec![RaftMessage { data: payload }];
+        let msgs = vec![RaftMessage {
+            shard_id: self.shard_id,
+            data: payload,
+        }];
         let stream = tokio_stream::iter(msgs);
 
         self.connect().await.map_err(Self::to_iss_unreachable)?;

--- a/crates/ggap-consensus/src/node.rs
+++ b/crates/ggap-consensus/src/node.rs
@@ -64,6 +64,11 @@ impl OpenRaftNode {
             node_id,
         }
     }
+
+    /// Access the underlying Raft instance (e.g. for ensure_linearizable).
+    pub fn raft(&self) -> &Arc<GgapRaft> {
+        &self.raft
+    }
 }
 
 impl RaftNode for OpenRaftNode {

--- a/crates/ggap-consensus/src/router.rs
+++ b/crates/ggap-consensus/src/router.rs
@@ -48,11 +48,10 @@ impl ShardRouter {
 
     /// Look up the RaftNode for a read operation on the given key.
     pub async fn route_read(&self, key: &str) -> Result<Arc<OpenRaftNode>, GgapError> {
-        let info = self
-            .shard_map
-            .lookup_shard(key)
-            .await
-            .ok_or_else(|| GgapError::InvalidArgument(format!("no shard found for key '{key}'")))?;
+        let info =
+            self.shard_map.lookup_shard(key).await.ok_or_else(|| {
+                GgapError::InvalidArgument(format!("no shard found for key '{key}'"))
+            })?;
 
         let nodes = self.nodes.read().await;
         nodes
@@ -67,11 +66,10 @@ impl ShardRouter {
     /// Look up the RaftNode for a write operation on the given key.
     /// Returns `ShardSplitting` if the shard is currently being split.
     pub async fn route_write(&self, key: &str) -> Result<Arc<OpenRaftNode>, GgapError> {
-        let info = self
-            .shard_map
-            .lookup_shard(key)
-            .await
-            .ok_or_else(|| GgapError::InvalidArgument(format!("no shard found for key '{key}'")))?;
+        let info =
+            self.shard_map.lookup_shard(key).await.ok_or_else(|| {
+                GgapError::InvalidArgument(format!("no shard found for key '{key}'"))
+            })?;
 
         if info.state == ShardState::Splitting {
             return Err(GgapError::ShardSplitting);
@@ -94,9 +92,13 @@ impl ShardRouter {
         start_key: &str,
         end_key: &str,
     ) -> Result<Arc<OpenRaftNode>, GgapError> {
-        let info = self.shard_map.lookup_shard(start_key).await.ok_or_else(|| {
-            GgapError::InvalidArgument(format!("no shard found for key '{start_key}'"))
-        })?;
+        let info = self
+            .shard_map
+            .lookup_shard(start_key)
+            .await
+            .ok_or_else(|| {
+                GgapError::InvalidArgument(format!("no shard found for key '{start_key}'"))
+            })?;
 
         // If end_key is specified and falls outside this shard's range, reject
         if !end_key.is_empty() && !info.range.contains(end_key) {

--- a/crates/ggap-consensus/src/router.rs
+++ b/crates/ggap-consensus/src/router.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use ggap_storage::ShardMap;
+use ggap_types::{GgapError, ShardId, ShardState};
+
+use crate::node::{OpenRaftCluster, OpenRaftNode};
+
+/// Routes KV requests to the correct shard's `RaftNode` based on key ranges,
+/// and routes inbound Raft RPCs to the correct shard's `ClusterNode`.
+pub struct ShardRouter {
+    shard_map: Arc<ShardMap>,
+    nodes: RwLock<HashMap<ShardId, Arc<OpenRaftNode>>>,
+    clusters: RwLock<HashMap<ShardId, Arc<OpenRaftCluster>>>,
+}
+
+impl ShardRouter {
+    pub fn new(shard_map: Arc<ShardMap>) -> Self {
+        ShardRouter {
+            shard_map,
+            nodes: RwLock::new(HashMap::new()),
+            clusters: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn shard_map(&self) -> &Arc<ShardMap> {
+        &self.shard_map
+    }
+
+    /// Register a shard's RaftNode and ClusterNode.
+    pub async fn add_shard(
+        &self,
+        shard_id: ShardId,
+        node: Arc<OpenRaftNode>,
+        cluster: Arc<OpenRaftCluster>,
+    ) {
+        self.nodes.write().await.insert(shard_id, node);
+        self.clusters.write().await.insert(shard_id, cluster);
+    }
+
+    /// Remove a shard's registration.
+    pub async fn remove_shard(&self, shard_id: ShardId) {
+        self.nodes.write().await.remove(&shard_id);
+        self.clusters.write().await.remove(&shard_id);
+    }
+
+    /// Look up the RaftNode for a read operation on the given key.
+    pub async fn route_read(&self, key: &str) -> Result<Arc<OpenRaftNode>, GgapError> {
+        let info = self
+            .shard_map
+            .lookup_shard(key)
+            .await
+            .ok_or_else(|| GgapError::InvalidArgument(format!("no shard found for key '{key}'")))?;
+
+        let nodes = self.nodes.read().await;
+        nodes
+            .get(&info.shard_id)
+            .cloned()
+            .ok_or(GgapError::WrongShard {
+                shard_id: info.shard_id,
+                range: info.range,
+            })
+    }
+
+    /// Look up the RaftNode for a write operation on the given key.
+    /// Returns `ShardSplitting` if the shard is currently being split.
+    pub async fn route_write(&self, key: &str) -> Result<Arc<OpenRaftNode>, GgapError> {
+        let info = self
+            .shard_map
+            .lookup_shard(key)
+            .await
+            .ok_or_else(|| GgapError::InvalidArgument(format!("no shard found for key '{key}'")))?;
+
+        if info.state == ShardState::Splitting {
+            return Err(GgapError::ShardSplitting);
+        }
+
+        let nodes = self.nodes.read().await;
+        nodes
+            .get(&info.shard_id)
+            .cloned()
+            .ok_or(GgapError::WrongShard {
+                shard_id: info.shard_id,
+                range: info.range,
+            })
+    }
+
+    /// Look up the RaftNode for a scan operation.
+    /// For correctness, the entire scan range must be within a single shard.
+    pub async fn route_scan(
+        &self,
+        start_key: &str,
+        end_key: &str,
+    ) -> Result<Arc<OpenRaftNode>, GgapError> {
+        let info = self.shard_map.lookup_shard(start_key).await.ok_or_else(|| {
+            GgapError::InvalidArgument(format!("no shard found for key '{start_key}'"))
+        })?;
+
+        // If end_key is specified and falls outside this shard's range, reject
+        if !end_key.is_empty() && !info.range.contains(end_key) {
+            // Check that end_key is at most the shard boundary
+            // (end_key == shard.range.end is acceptable as an exclusive bound)
+            if !info.range.end.is_empty() && end_key > info.range.end.as_str() {
+                return Err(GgapError::InvalidArgument(
+                    "scan range spans multiple shards".into(),
+                ));
+            }
+        }
+
+        let nodes = self.nodes.read().await;
+        nodes
+            .get(&info.shard_id)
+            .cloned()
+            .ok_or(GgapError::WrongShard {
+                shard_id: info.shard_id,
+                range: info.range,
+            })
+    }
+
+    /// Get the ClusterNode for a specific shard (for inbound Raft RPCs).
+    pub async fn get_cluster(&self, shard_id: ShardId) -> Option<Arc<OpenRaftCluster>> {
+        self.clusters.read().await.get(&shard_id).cloned()
+    }
+
+    /// Get the RaftNode for a specific shard by id.
+    pub async fn get_node(&self, shard_id: ShardId) -> Option<Arc<OpenRaftNode>> {
+        self.nodes.read().await.get(&shard_id).cloned()
+    }
+}

--- a/crates/ggap-consensus/src/split.rs
+++ b/crates/ggap-consensus/src/split.rs
@@ -1,0 +1,246 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::{BasicNode, ServerState};
+
+use ggap_storage::fjall::{FjallStateMachine, FjallStore};
+use ggap_storage::ShardMap;
+use ggap_types::{GgapError, KeyRange, ShardId, ShardInfo, ShardState};
+
+use crate::config::build_raft_config;
+use crate::log_store::GgapLogStorage;
+use crate::network::GgapNetworkFactory;
+use crate::node::{GgapRaft, OpenRaftCluster, OpenRaftNode};
+use crate::router::ShardRouter;
+use crate::state_machine::GgapStateMachine;
+
+/// Coordinates the split of a shard's key range into two shards.
+///
+/// The split protocol blocks writes on the source shard during the split
+/// to ensure consistency. The steps are:
+///
+/// 1. Validate the split request
+/// 2. Mark source shard as Splitting (blocks writes via router)
+/// 3. Write barrier: propose a no-op and wait for commit
+/// 4. Build partial snapshot of keys >= split_key
+/// 5. Bootstrap new Raft group with new ShardId
+/// 6. Install partial snapshot on new shard
+/// 7. Delete transferred keys from source shard
+/// 8. Update ShardMap with new ranges
+/// 9. Resume writes on source shard (state → Active)
+pub struct SplitCoordinator {
+    router: Arc<ShardRouter>,
+    shard_map: Arc<ShardMap>,
+    store: Arc<FjallStore>,
+    fsm: Arc<FjallStateMachine>,
+    node_id: u64,
+    cluster_addr: String,
+    /// Raft config parameters for new shard groups.
+    heartbeat_ms: u64,
+    election_min_ms: u64,
+    election_max_ms: u64,
+}
+
+impl SplitCoordinator {
+    pub fn new(
+        router: Arc<ShardRouter>,
+        shard_map: Arc<ShardMap>,
+        store: Arc<FjallStore>,
+        fsm: Arc<FjallStateMachine>,
+        node_id: u64,
+        cluster_addr: String,
+        heartbeat_ms: u64,
+        election_min_ms: u64,
+        election_max_ms: u64,
+    ) -> Self {
+        SplitCoordinator {
+            router,
+            shard_map,
+            store,
+            fsm,
+            node_id,
+            cluster_addr,
+            heartbeat_ms,
+            election_min_ms,
+            election_max_ms,
+        }
+    }
+
+    /// Execute a shard split at the given key.
+    ///
+    /// Returns the new shard id on success.
+    pub async fn split(
+        &self,
+        shard_id: ShardId,
+        split_key: &str,
+    ) -> Result<ShardId, GgapError> {
+        // 1. Validate
+        let source_info = self
+            .shard_map
+            .get_shard(shard_id)
+            .await
+            .ok_or(GgapError::ShardNotFound(shard_id))?;
+
+        if source_info.state != ShardState::Active {
+            return Err(GgapError::InvalidArgument(
+                "shard is not in Active state".into(),
+            ));
+        }
+
+        if !source_info.range.contains(split_key) {
+            return Err(GgapError::InvalidArgument(format!(
+                "split_key '{}' is not within shard {}'s range [{}, {})",
+                split_key, shard_id, source_info.range.start, source_info.range.end
+            )));
+        }
+
+        if split_key == source_info.range.start {
+            return Err(GgapError::InvalidArgument(
+                "split_key cannot be the shard's start key".into(),
+            ));
+        }
+
+        // 2. Mark source shard as Splitting
+        let splitting_info = ShardInfo {
+            shard_id,
+            range: source_info.range.clone(),
+            state: ShardState::Splitting,
+        };
+        self.shard_map.put_shard(splitting_info).await?;
+
+        // From here on, if we fail, we need to restore the source shard to Active.
+        let result = self
+            .do_split(shard_id, split_key, &source_info)
+            .await;
+
+        match result {
+            Ok(new_shard_id) => Ok(new_shard_id),
+            Err(e) => {
+                // Restore source shard to Active on failure
+                tracing::error!(
+                    shard_id,
+                    split_key,
+                    error = %e,
+                    "split failed, restoring source shard to Active"
+                );
+                let restored = ShardInfo {
+                    shard_id,
+                    range: source_info.range.clone(),
+                    state: ShardState::Active,
+                };
+                let _ = self.shard_map.put_shard(restored).await;
+                Err(e)
+            }
+        }
+    }
+
+    async fn do_split(
+        &self,
+        shard_id: ShardId,
+        split_key: &str,
+        source_info: &ShardInfo,
+    ) -> Result<ShardId, GgapError> {
+        // 3. Write barrier: propose a no-op through the source shard's Raft
+        let source_node = self
+            .router
+            .get_node(shard_id)
+            .await
+            .ok_or(GgapError::ShardNotFound(shard_id))?;
+
+        // Use a Put with empty key as a barrier — just ensure linearizability
+        source_node
+            .raft()
+            .ensure_linearizable()
+            .await
+            .map_err(|e| GgapError::Consensus(format!("write barrier failed: {e}")))?;
+
+        // 4. Build partial snapshot of keys >= split_key
+        let contents = self
+            .fsm
+            .build_partial_snapshot(shard_id, split_key)
+            .await?;
+
+        // 5. Allocate new shard id
+        let new_shard_id = self.shard_map.next_shard_id().await;
+
+        // 6. Install partial snapshot on new shard
+        self.fsm
+            .install_partial_snapshot(new_shard_id, &contents)
+            .await?;
+
+        // 7. Delete transferred keys from source shard
+        self.fsm.delete_range_from(shard_id, split_key).await?;
+
+        // 8. Update ShardMap: narrow source, add new shard
+        let updated_source = ShardInfo {
+            shard_id,
+            range: KeyRange {
+                start: source_info.range.start.clone(),
+                end: split_key.to_string(),
+            },
+            state: ShardState::Active,
+        };
+        let new_shard = ShardInfo {
+            shard_id: new_shard_id,
+            range: KeyRange {
+                start: split_key.to_string(),
+                end: source_info.range.end.clone(),
+            },
+            state: ShardState::Active,
+        };
+        self.shard_map.put_shard(updated_source).await?;
+        self.shard_map.put_shard(new_shard).await?;
+
+        // 9. Bootstrap new Raft group for the new shard
+        let log_store = GgapLogStorage::new(self.store.clone(), new_shard_id);
+        let sm = GgapStateMachine::new(self.fsm.clone(), new_shard_id);
+        let net = GgapNetworkFactory::new(new_shard_id);
+        let cfg = build_raft_config(self.heartbeat_ms, self.election_min_ms, self.election_max_ms);
+
+        let raft = Arc::new(
+            GgapRaft::new(self.node_id, cfg, net, log_store, sm)
+                .await
+                .map_err(|e| GgapError::Consensus(format!("failed to create Raft for new shard: {e}")))?,
+        );
+
+        // Initialize as single-node cluster
+        let mut members = BTreeMap::new();
+        members.insert(
+            self.node_id,
+            BasicNode {
+                addr: self.cluster_addr.clone(),
+            },
+        );
+        raft.initialize(members)
+            .await
+            .map_err(|e| GgapError::Consensus(format!("failed to initialize new shard Raft: {e}")))?;
+
+        // Wait for the new shard to become leader
+        raft.wait(Some(Duration::from_secs(5)))
+            .state(ServerState::Leader, "new shard become leader")
+            .await
+            .map_err(|e| GgapError::Consensus(format!("new shard did not become leader: {e}")))?;
+
+        // 10. Register in router
+        let new_node = Arc::new(OpenRaftNode::new(
+            raft.clone(),
+            self.fsm.clone(),
+            new_shard_id,
+            self.node_id,
+        ));
+        let new_cluster = Arc::new(OpenRaftCluster::new(raft));
+        self.router
+            .add_shard(new_shard_id, new_node, new_cluster)
+            .await;
+
+        tracing::info!(
+            shard_id,
+            new_shard_id,
+            split_key,
+            "shard split completed successfully"
+        );
+
+        Ok(new_shard_id)
+    }
+}

--- a/crates/ggap-consensus/src/split.rs
+++ b/crates/ggap-consensus/src/split.rs
@@ -15,6 +15,19 @@ use crate::node::{GgapRaft, OpenRaftCluster, OpenRaftNode};
 use crate::router::ShardRouter;
 use crate::state_machine::GgapStateMachine;
 
+/// Parameters needed to construct a `SplitCoordinator`.
+pub struct SplitCoordinatorConfig {
+    pub router: Arc<ShardRouter>,
+    pub shard_map: Arc<ShardMap>,
+    pub store: Arc<FjallStore>,
+    pub fsm: Arc<FjallStateMachine>,
+    pub node_id: u64,
+    pub cluster_addr: String,
+    pub heartbeat_ms: u64,
+    pub election_min_ms: u64,
+    pub election_max_ms: u64,
+}
+
 /// Coordinates the split of a shard's key range into two shards.
 ///
 /// The split protocol blocks writes on the source shard during the split
@@ -36,45 +49,30 @@ pub struct SplitCoordinator {
     fsm: Arc<FjallStateMachine>,
     node_id: u64,
     cluster_addr: String,
-    /// Raft config parameters for new shard groups.
     heartbeat_ms: u64,
     election_min_ms: u64,
     election_max_ms: u64,
 }
 
 impl SplitCoordinator {
-    pub fn new(
-        router: Arc<ShardRouter>,
-        shard_map: Arc<ShardMap>,
-        store: Arc<FjallStore>,
-        fsm: Arc<FjallStateMachine>,
-        node_id: u64,
-        cluster_addr: String,
-        heartbeat_ms: u64,
-        election_min_ms: u64,
-        election_max_ms: u64,
-    ) -> Self {
+    pub fn new(cfg: SplitCoordinatorConfig) -> Self {
         SplitCoordinator {
-            router,
-            shard_map,
-            store,
-            fsm,
-            node_id,
-            cluster_addr,
-            heartbeat_ms,
-            election_min_ms,
-            election_max_ms,
+            router: cfg.router,
+            shard_map: cfg.shard_map,
+            store: cfg.store,
+            fsm: cfg.fsm,
+            node_id: cfg.node_id,
+            cluster_addr: cfg.cluster_addr,
+            heartbeat_ms: cfg.heartbeat_ms,
+            election_min_ms: cfg.election_min_ms,
+            election_max_ms: cfg.election_max_ms,
         }
     }
 
     /// Execute a shard split at the given key.
     ///
     /// Returns the new shard id on success.
-    pub async fn split(
-        &self,
-        shard_id: ShardId,
-        split_key: &str,
-    ) -> Result<ShardId, GgapError> {
+    pub async fn split(&self, shard_id: ShardId, split_key: &str) -> Result<ShardId, GgapError> {
         // 1. Validate
         let source_info = self
             .shard_map
@@ -110,9 +108,7 @@ impl SplitCoordinator {
         self.shard_map.put_shard(splitting_info).await?;
 
         // From here on, if we fail, we need to restore the source shard to Active.
-        let result = self
-            .do_split(shard_id, split_key, &source_info)
-            .await;
+        let result = self.do_split(shard_id, split_key, &source_info).await;
 
         match result {
             Ok(new_shard_id) => Ok(new_shard_id),
@@ -156,10 +152,7 @@ impl SplitCoordinator {
             .map_err(|e| GgapError::Consensus(format!("write barrier failed: {e}")))?;
 
         // 4. Build partial snapshot of keys >= split_key
-        let contents = self
-            .fsm
-            .build_partial_snapshot(shard_id, split_key)
-            .await?;
+        let contents = self.fsm.build_partial_snapshot(shard_id, split_key).await?;
 
         // 5. Allocate new shard id
         let new_shard_id = self.shard_map.next_shard_id().await;
@@ -196,12 +189,18 @@ impl SplitCoordinator {
         let log_store = GgapLogStorage::new(self.store.clone(), new_shard_id);
         let sm = GgapStateMachine::new(self.fsm.clone(), new_shard_id);
         let net = GgapNetworkFactory::new(new_shard_id);
-        let cfg = build_raft_config(self.heartbeat_ms, self.election_min_ms, self.election_max_ms);
+        let cfg = build_raft_config(
+            self.heartbeat_ms,
+            self.election_min_ms,
+            self.election_max_ms,
+        );
 
         let raft = Arc::new(
             GgapRaft::new(self.node_id, cfg, net, log_store, sm)
                 .await
-                .map_err(|e| GgapError::Consensus(format!("failed to create Raft for new shard: {e}")))?,
+                .map_err(|e| {
+                    GgapError::Consensus(format!("failed to create Raft for new shard: {e}"))
+                })?,
         );
 
         // Initialize as single-node cluster
@@ -212,9 +211,9 @@ impl SplitCoordinator {
                 addr: self.cluster_addr.clone(),
             },
         );
-        raft.initialize(members)
-            .await
-            .map_err(|e| GgapError::Consensus(format!("failed to initialize new shard Raft: {e}")))?;
+        raft.initialize(members).await.map_err(|e| {
+            GgapError::Consensus(format!("failed to initialize new shard Raft: {e}"))
+        })?;
 
         // Wait for the new shard to become leader
         raft.wait(Some(Duration::from_secs(5)))

--- a/crates/ggap-consensus/tests/single_node.rs
+++ b/crates/ggap-consensus/tests/single_node.rs
@@ -19,7 +19,7 @@ async fn single_node_leader_write_read() {
     let fsm = Arc::new(FjallStateMachine::new(store.clone()));
     let log_store = GgapLogStorage::new(store.clone(), 0);
     let sm = GgapStateMachine::new(fsm.clone(), 0);
-    let net = GgapNetworkFactory;
+    let net = GgapNetworkFactory::new(0);
     let cfg = build_raft_config(50, 150, 300);
 
     let raft = Arc::new(GgapRaft::new(1, cfg, net, log_store, sm).await.unwrap());

--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -12,12 +12,13 @@ use serde::Deserialize;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode,
+    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator,
 };
 use ggap_server::{serve_client, serve_cluster};
 use ggap_storage::{
     fjall::{FjallStateMachine, FjallStore},
     ttl::TtlGcTask,
+    ShardMap,
 };
 
 #[derive(clap::Parser, Debug)]
@@ -154,62 +155,99 @@ async fn main() -> anyhow::Result<()> {
     let store = FjallStore::open(&data_dir)
         .with_context(|| format!("failed to open FjallStore at {}", data_dir.display()))?;
 
-    // 2. Create FSM and log store.
-    let fsm = Arc::new(FjallStateMachine::new(store.clone()));
-    let log_store = GgapLogStorage::new(store.clone(), 0);
-    let sm = GgapStateMachine::new(fsm.clone(), 0);
+    // 2. Load or initialize ShardMap.
+    let shard_map = Arc::new(
+        ShardMap::load(store.clone()).context("failed to load shard map")?,
+    );
+    shard_map
+        .initialize_default()
+        .await
+        .context("failed to initialize default shard")?;
 
-    // 3. Build Raft config from file config.
+    // 3. Create FSM (shared across all shards).
+    let fsm = Arc::new(FjallStateMachine::new(store.clone()));
+
+    // 4. Create ShardRouter.
+    let router = Arc::new(ShardRouter::new(shard_map.clone()));
+
+    // 5. Start a Raft group for each shard in the ShardMap.
+    let shards = shard_map.all_shards().await;
     let raft_cfg = build_raft_config(
         config.raft.heartbeat_interval_ms,
         config.raft.election_timeout_min_ms,
         config.raft.election_timeout_max_ms,
     );
 
-    // 4. Create the Raft instance.
-    let net = GgapNetworkFactory;
-    let raft = Arc::new(
-        GgapRaft::new(cli.node_id, raft_cfg, net, log_store, sm)
-            .await
-            .context("failed to create Raft instance")?,
-    );
+    for shard_info in &shards {
+        let shard_id = shard_info.shard_id;
+        let log_store = GgapLogStorage::new(store.clone(), shard_id);
+        let sm = GgapStateMachine::new(fsm.clone(), shard_id);
+        let net = GgapNetworkFactory::new(shard_id);
 
-    // 5. Initialize as single-node cluster on first boot.
-    if !raft
-        .is_initialized()
-        .await
-        .context("raft.is_initialized failed")?
-    {
-        let mut members = BTreeMap::new();
-        members.insert(
-            cli.node_id,
-            BasicNode {
-                addr: cluster_addr.to_string(),
-            },
+        let raft = Arc::new(
+            GgapRaft::new(cli.node_id, raft_cfg.clone(), net, log_store, sm)
+                .await
+                .with_context(|| format!("failed to create Raft for shard {shard_id}"))?,
         );
-        raft.initialize(members)
+
+        // Initialize as single-node cluster on first boot (only for shard 0 initially).
+        if !raft
+            .is_initialized()
             .await
-            .map_err(|e| anyhow::anyhow!("raft.initialize failed: {}", e))?;
+            .with_context(|| format!("raft.is_initialized failed for shard {shard_id}"))?
+        {
+            let mut members = BTreeMap::new();
+            members.insert(
+                cli.node_id,
+                BasicNode {
+                    addr: cluster_addr.to_string(),
+                },
+            );
+            raft.initialize(members)
+                .await
+                .map_err(|e| anyhow::anyhow!("raft.initialize failed for shard {shard_id}: {e}"))?;
+        }
+
+        let node = Arc::new(OpenRaftNode::new(
+            raft.clone(),
+            fsm.clone(),
+            shard_id,
+            cli.node_id,
+        ));
+        let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
+
+        router.add_shard(shard_id, node, cluster).await;
+
+        // Spawn TTL GC task for this shard.
+        let (ttl_tx, mut ttl_rx) = tokio::sync::mpsc::channel(256);
+        tokio::spawn(TtlGcTask::new(fsm.clone(), shard_id, ttl_tx).run());
+        let raft2 = raft.clone();
+        tokio::spawn(async move {
+            while let Some(cmd) = ttl_rx.recv().await {
+                let _ = raft2.client_write(cmd).await;
+            }
+        });
+
+        tracing::info!(shard_id, "started Raft group");
     }
 
-    // 6. Build the node and cluster handles.
-    let node = Arc::new(OpenRaftNode::new(raft.clone(), fsm.clone(), 0, cli.node_id));
-    let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
+    // 6. Create the SplitCoordinator.
+    let split_coordinator = Arc::new(SplitCoordinator::new(
+        router.clone(),
+        shard_map.clone(),
+        store.clone(),
+        fsm.clone(),
+        cli.node_id,
+        cluster_addr.to_string(),
+        config.raft.heartbeat_interval_ms,
+        config.raft.election_timeout_min_ms,
+        config.raft.election_timeout_max_ms,
+    ));
 
-    // 7. Spawn TTL GC task, wired through Raft.
-    let (ttl_tx, mut ttl_rx) = tokio::sync::mpsc::channel(256);
-    tokio::spawn(TtlGcTask::new(fsm.clone(), 0, ttl_tx).run());
-    let raft2 = raft.clone();
-    tokio::spawn(async move {
-        while let Some(cmd) = ttl_rx.recv().await {
-            let _ = raft2.client_write(cmd).await;
-        }
-    });
-
-    // 8. Serve.
+    // 7. Serve.
     tokio::try_join!(
-        serve_client(client_addr, node, cli.node_id),
-        serve_cluster(cluster_addr, cluster),
+        serve_client(client_addr, router.clone(), cli.node_id),
+        serve_cluster(cluster_addr, router, split_coordinator, shard_map),
     )?;
 
     Ok(())

--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator,
+    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
 use ggap_server::{serve_client, serve_cluster};
 use ggap_storage::{
@@ -156,9 +156,7 @@ async fn main() -> anyhow::Result<()> {
         .with_context(|| format!("failed to open FjallStore at {}", data_dir.display()))?;
 
     // 2. Load or initialize ShardMap.
-    let shard_map = Arc::new(
-        ShardMap::load(store.clone()).context("failed to load shard map")?,
-    );
+    let shard_map = Arc::new(ShardMap::load(store.clone()).context("failed to load shard map")?);
     shard_map
         .initialize_default()
         .await
@@ -232,17 +230,17 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // 6. Create the SplitCoordinator.
-    let split_coordinator = Arc::new(SplitCoordinator::new(
-        router.clone(),
-        shard_map.clone(),
-        store.clone(),
-        fsm.clone(),
-        cli.node_id,
-        cluster_addr.to_string(),
-        config.raft.heartbeat_interval_ms,
-        config.raft.election_timeout_min_ms,
-        config.raft.election_timeout_max_ms,
-    ));
+    let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
+        router: router.clone(),
+        shard_map: shard_map.clone(),
+        store: store.clone(),
+        fsm: fsm.clone(),
+        node_id: cli.node_id,
+        cluster_addr: cluster_addr.to_string(),
+        heartbeat_ms: config.raft.heartbeat_interval_ms,
+        election_min_ms: config.raft.election_timeout_min_ms,
+        election_max_ms: config.raft.election_timeout_max_ms,
+    }));
 
     // 7. Serve.
     tokio::try_join!(

--- a/crates/ggap-server/Cargo.toml
+++ b/crates/ggap-server/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 ggap-types     = { path = "../ggap-types" }
 ggap-consensus = { path = "../ggap-consensus" }
+ggap-storage   = { path = "../ggap-storage" }
 ggap-proto     = { path = "../ggap-proto" }
 tonic             = { workspace = true }
 tonic-reflection  = { workspace = true }

--- a/crates/ggap-server/benches/kv_write.rs
+++ b/crates/ggap-server/benches/kv_write.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator,
+    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
 use ggap_proto::v1::{kv_service_client::KvServiceClient, PutRequest};
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener};
@@ -79,17 +79,17 @@ async fn start_node(id: u64) -> BenchNode {
     let router = Arc::new(ShardRouter::new(shard_map.clone()));
     router.add_shard(0, raft_node, cluster).await;
 
-    let split_coordinator = Arc::new(SplitCoordinator::new(
-        router.clone(),
-        shard_map.clone(),
+    let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
+        router: router.clone(),
+        shard_map: shard_map.clone(),
         store,
         fsm,
-        id,
-        cluster_addr.to_string(),
-        HEARTBEAT_MS,
-        ELECTION_MIN_MS,
-        ELECTION_MAX_MS,
-    ));
+        node_id: id,
+        cluster_addr: cluster_addr.to_string(),
+        heartbeat_ms: HEARTBEAT_MS,
+        election_min_ms: ELECTION_MIN_MS,
+        election_max_ms: ELECTION_MAX_MS,
+    }));
 
     let mut handles = Vec::new();
 

--- a/crates/ggap-server/benches/kv_write.rs
+++ b/crates/ggap-server/benches/kv_write.rs
@@ -4,10 +4,6 @@
 //! then drives Put RPCs through the KV gRPC service with UUID keys and
 //! 1–2 KB random values.
 //!
-//! Leader redirects (Code::Unavailable + ggap-leader-addr header) are
-//! followed automatically, so the measurement is not sensitive to the
-//! rare leader changes that may occur under heavy load.
-//!
 //! Run with:
 //!   cargo bench -p ggap-server --bench kv_write
 
@@ -25,31 +21,23 @@ use uuid::Uuid;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode,
+    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator,
 };
 use ggap_proto::v1::{kv_service_client::KvServiceClient, PutRequest};
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener};
 use ggap_storage::fjall::{FjallStateMachine, FjallStore};
+use ggap_storage::ShardMap;
 
 // ---------------------------------------------------------------------------
 // Tuning knobs
 // ---------------------------------------------------------------------------
 
 const TOTAL_WRITES: usize = 1_000_000;
-
-/// Maximum number of in-flight gRPC calls. HTTP/2 multiplexes them over
-/// a single connection.
 const CONCURRENCY: usize = 512;
-
-/// Conservative timeouts — keeps the leader stable under write pressure.
-/// (heartbeat, election_min, election_max) in milliseconds.
 const HEARTBEAT_MS: u64 = 500;
 const ELECTION_MIN_MS: u64 = 1_500;
 const ELECTION_MAX_MS: u64 = 3_000;
-
-/// Pre-generated random buffer; value slices are cut from it.
 const RAND_BUF_SIZE: usize = 4 * 1024 * 1024;
-
 const REPORT_INTERVAL: usize = 100_000;
 
 // ---------------------------------------------------------------------------
@@ -73,7 +61,7 @@ async fn start_node(id: u64) -> BenchNode {
     let sm = GgapStateMachine::new(fsm.clone(), 0);
     let cfg = build_raft_config(HEARTBEAT_MS, ELECTION_MIN_MS, ELECTION_MAX_MS);
     let raft = Arc::new(
-        GgapRaft::new(id, cfg, GgapNetworkFactory, log_store, sm)
+        GgapRaft::new(id, cfg, GgapNetworkFactory::new(0), log_store, sm)
             .await
             .unwrap_or_else(|e| panic!("node {id} init: {e}")),
     );
@@ -83,21 +71,40 @@ async fn start_node(id: u64) -> BenchNode {
     let client_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let client_addr = client_listener.local_addr().unwrap();
 
-    let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
     let raft_node = Arc::new(OpenRaftNode::new(raft.clone(), fsm.clone(), 0, id));
+    let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
+
+    let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
+    shard_map.initialize_default().await.unwrap();
+    let router = Arc::new(ShardRouter::new(shard_map.clone()));
+    router.add_shard(0, raft_node, cluster).await;
+
+    let split_coordinator = Arc::new(SplitCoordinator::new(
+        router.clone(),
+        shard_map.clone(),
+        store,
+        fsm,
+        id,
+        cluster_addr.to_string(),
+        HEARTBEAT_MS,
+        ELECTION_MIN_MS,
+        ELECTION_MAX_MS,
+    ));
 
     let mut handles = Vec::new();
 
-    let c = cluster.clone();
+    let r = router.clone();
+    let sc = split_coordinator.clone();
+    let sm2 = shard_map.clone();
     handles.push(tokio::spawn(async move {
-        if let Err(e) = serve_cluster_with_listener(cluster_listener, c).await {
+        if let Err(e) = serve_cluster_with_listener(cluster_listener, r, sc, sm2).await {
             eprintln!("node {id} cluster: {e}");
         }
     }));
 
-    let n = raft_node.clone();
+    let r = router.clone();
     handles.push(tokio::spawn(async move {
-        if let Err(e) = serve_client_with_listener(client_listener, n, id).await {
+        if let Err(e) = serve_client_with_listener(client_listener, r, id).await {
             eprintln!("node {id} client: {e}");
         }
     }));
@@ -186,7 +193,6 @@ async fn connect(addr: SocketAddr) -> KvServiceClient<tonic::transport::Channel>
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
-    // ── Cluster setup ─────────────────────────────────────────────────────
     eprint!("Starting 3-node cluster … ");
     let cluster = BenchCluster::start(3).await;
     let leader_idx = cluster.wait_for_leader().await;
@@ -196,7 +202,6 @@ async fn main() {
         cluster.nodes[leader_idx].id, leader_addr
     );
 
-    // Snapshot of (raft, client_addr) pairs for leader re-discovery on redirect.
     let nodes_info: Arc<Vec<(Arc<GgapRaft>, SocketAddr)>> = Arc::new(
         cluster
             .nodes
@@ -205,24 +210,19 @@ async fn main() {
             .collect(),
     );
 
-    // Shared gRPC client — swapped out whenever a leader redirect is received.
     let shared_client: Arc<RwLock<KvServiceClient<tonic::transport::Channel>>> =
         Arc::new(RwLock::new(connect(leader_addr).await));
 
-    // ── Random value buffer ────────────────────────────────────────────────
     let rand_buf: Arc<Vec<u8>> =
         Arc::new((0..RAND_BUF_SIZE).map(|_| rand::random::<u8>()).collect());
 
-    // ── Benchmark ─────────────────────────────────────────────────────────
     eprintln!("\nWriting {TOTAL_WRITES} keys ({CONCURRENCY} in-flight, 1–2 KB values) …\n");
     let start = Instant::now();
 
     let stream = futures::stream::iter(0..TOTAL_WRITES)
         .map(|i| {
-            // Generate key / value parameters synchronously to avoid Send
-            // issues with thread-local RNGs inside async blocks.
             let key = Uuid::new_v4().to_string();
-            let value_len = 1024 + rand::random::<u64>() as usize % 1025; // [1024, 2048]
+            let value_len = 1024 + rand::random::<u64>() as usize % 1025;
             let offset = rand::random::<u64>() as usize % (RAND_BUF_SIZE - value_len + 1);
 
             let shared_client = shared_client.clone();
@@ -243,21 +243,17 @@ async fn main() {
                     {
                         Ok(_) => return,
                         Err(status) if status.code() == tonic::Code::Unavailable => {
-                            // The server returned NotLeader. Follow the hint
-                            // (ggap-leader-addr header) or poll cluster metrics.
                             let new_addr = status
                                 .metadata()
                                 .get("ggap-leader-addr")
                                 .and_then(|v| v.to_str().ok())
                                 .and_then(|s| s.parse::<SocketAddr>().ok());
 
-                            // Back off briefly so the new leader can stabilise.
                             tokio::time::sleep(Duration::from_millis(200)).await;
 
                             let addr = match new_addr {
                                 Some(a) => a,
                                 None => {
-                                    // No hint — scan raft metrics directly.
                                     let deadline = Instant::now() + Duration::from_secs(5);
                                     loop {
                                         let found = nodes_info.iter().find_map(|(raft, addr)| {
@@ -303,7 +299,6 @@ async fn main() {
 
     let elapsed = start.elapsed();
     let wps = TOTAL_WRITES as f64 / elapsed.as_secs_f64();
-    // Average value size ≈ 1.5 KB
     let mbs = TOTAL_WRITES as f64 * 1536.0 / (1u64 << 20) as f64 / elapsed.as_secs_f64();
 
     println!("\n── Results ────────────────────────────────────────────────");

--- a/crates/ggap-server/src/admin_service.rs
+++ b/crates/ggap-server/src/admin_service.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use ggap_consensus::SplitCoordinator;
 use ggap_proto::v1::{
     admin_service_server::AdminService, AddLearnerRequest, AddLearnerResponse,
-    ChangeMembershipRequest, ChangeMembershipResponse, ClusterStatusRequest,
-    ClusterStatusResponse, ListShardsRequest, ListShardsResponse, ShardInfoProto,
-    SplitShardRequest, SplitShardResponse, TransferLeaderRequest, TransferLeaderResponse,
+    ChangeMembershipRequest, ChangeMembershipResponse, ClusterStatusRequest, ClusterStatusResponse,
+    ListShardsRequest, ListShardsResponse, ShardInfoProto, SplitShardRequest, SplitShardResponse,
+    TransferLeaderRequest, TransferLeaderResponse,
 };
 use ggap_storage::ShardMap;
 use tonic::{Request, Response, Status};

--- a/crates/ggap-server/src/admin_service.rs
+++ b/crates/ggap-server/src/admin_service.rs
@@ -1,11 +1,28 @@
+use std::sync::Arc;
+
+use ggap_consensus::SplitCoordinator;
 use ggap_proto::v1::{
     admin_service_server::AdminService, AddLearnerRequest, AddLearnerResponse,
-    ChangeMembershipRequest, ChangeMembershipResponse, ClusterStatusRequest, ClusterStatusResponse,
-    TransferLeaderRequest, TransferLeaderResponse,
+    ChangeMembershipRequest, ChangeMembershipResponse, ClusterStatusRequest,
+    ClusterStatusResponse, ListShardsRequest, ListShardsResponse, ShardInfoProto,
+    SplitShardRequest, SplitShardResponse, TransferLeaderRequest, TransferLeaderResponse,
 };
+use ggap_storage::ShardMap;
 use tonic::{Request, Response, Status};
 
-pub struct AdminServiceImpl;
+pub struct AdminServiceImpl {
+    split_coordinator: Arc<SplitCoordinator>,
+    shard_map: Arc<ShardMap>,
+}
+
+impl AdminServiceImpl {
+    pub fn new(split_coordinator: Arc<SplitCoordinator>, shard_map: Arc<ShardMap>) -> Self {
+        AdminServiceImpl {
+            split_coordinator,
+            shard_map,
+        }
+    }
+}
 
 #[tonic::async_trait]
 impl AdminService for AdminServiceImpl {
@@ -13,27 +30,71 @@ impl AdminService for AdminServiceImpl {
         &self,
         _request: Request<ClusterStatusRequest>,
     ) -> Result<Response<ClusterStatusResponse>, Status> {
-        Err(Status::unimplemented("Phase 4"))
+        Err(Status::unimplemented("not yet implemented"))
     }
 
     async fn add_learner(
         &self,
         _request: Request<AddLearnerRequest>,
     ) -> Result<Response<AddLearnerResponse>, Status> {
-        Err(Status::unimplemented("Phase 4"))
+        Err(Status::unimplemented("not yet implemented"))
     }
 
     async fn change_membership(
         &self,
         _request: Request<ChangeMembershipRequest>,
     ) -> Result<Response<ChangeMembershipResponse>, Status> {
-        Err(Status::unimplemented("Phase 4"))
+        Err(Status::unimplemented("not yet implemented"))
     }
 
     async fn transfer_leader(
         &self,
         _request: Request<TransferLeaderRequest>,
     ) -> Result<Response<TransferLeaderResponse>, Status> {
-        Err(Status::unimplemented("Phase 4"))
+        Err(Status::unimplemented("not yet implemented"))
+    }
+
+    async fn split_shard(
+        &self,
+        request: Request<SplitShardRequest>,
+    ) -> Result<Response<SplitShardResponse>, Status> {
+        let req = request.into_inner();
+        if req.split_key.is_empty() {
+            return Err(Status::invalid_argument("split_key must not be empty"));
+        }
+
+        match self
+            .split_coordinator
+            .split(req.shard_id, &req.split_key)
+            .await
+        {
+            Ok(new_shard_id) => Ok(Response::new(SplitShardResponse {
+                ok: true,
+                new_shard_id,
+                error: String::new(),
+            })),
+            Err(e) => Ok(Response::new(SplitShardResponse {
+                ok: false,
+                new_shard_id: 0,
+                error: e.to_string(),
+            })),
+        }
+    }
+
+    async fn list_shards(
+        &self,
+        _request: Request<ListShardsRequest>,
+    ) -> Result<Response<ListShardsResponse>, Status> {
+        let shards = self.shard_map.all_shards().await;
+        let protos = shards
+            .into_iter()
+            .map(|s| ShardInfoProto {
+                shard_id: s.shard_id,
+                range_start: s.range.start,
+                range_end: s.range.end,
+                state: format!("{:?}", s.state),
+            })
+            .collect();
+        Ok(Response::new(ListShardsResponse { shards: protos }))
     }
 }

--- a/crates/ggap-server/src/convert.rs
+++ b/crates/ggap-server/src/convert.rs
@@ -55,5 +55,14 @@ pub fn ggap_to_status(err: GgapError) -> Status {
         GgapError::Timeout => Status::deadline_exceeded(err.to_string()),
         GgapError::Storage(_) | GgapError::Consensus(_) => Status::internal(err.to_string()),
         GgapError::InvalidArgument(_) => Status::invalid_argument(err.to_string()),
+        GgapError::WrongShard { shard_id, .. } => {
+            let mut status = Status::failed_precondition(err.to_string());
+            if let Ok(val) = MetadataValue::try_from(shard_id.to_string().as_str()) {
+                status.metadata_mut().insert("ggap-shard-id", val);
+            }
+            status
+        }
+        GgapError::ShardSplitting => Status::unavailable(err.to_string()),
+        GgapError::ShardNotFound(_) => Status::not_found(err.to_string()),
     }
 }

--- a/crates/ggap-server/src/kv_service.rs
+++ b/crates/ggap-server/src/kv_service.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ggap_consensus::RaftNode;
+use ggap_consensus::{RaftNode, ShardRouter};
 use ggap_proto::v1::{
     kv_service_server::KvService, CasRequest, CasResponse, DeleteRequest, DeleteResponse,
     GetRequest, GetResponse, PutRequest, PutResponse, ScanRequest, ScanResponse, WatchEvent,
@@ -14,27 +14,27 @@ use crate::convert::{
     ggap_to_status, kv_entry_to_proto, proto_read_consistency, proto_write_quorum, stub_header,
 };
 
-pub struct KvServiceImpl<R> {
-    raft: Arc<R>,
+pub struct KvServiceImpl {
+    router: Arc<ShardRouter>,
     node_id: u64,
 }
 
-impl<R: RaftNode> KvServiceImpl<R> {
-    pub fn new(raft: Arc<R>, node_id: u64) -> Self {
-        KvServiceImpl { raft, node_id }
+impl KvServiceImpl {
+    pub fn new(router: Arc<ShardRouter>, node_id: u64) -> Self {
+        KvServiceImpl { router, node_id }
     }
 }
 
 #[tonic::async_trait]
-impl<R: RaftNode> KvService for KvServiceImpl<R> {
+impl KvService for KvServiceImpl {
     async fn get(&self, request: Request<GetRequest>) -> Result<Response<GetResponse>, Status> {
         let req = request.into_inner();
         if req.key.is_empty() {
             return Err(Status::invalid_argument("key must not be empty"));
         }
         let mode = proto_read_consistency(req.consistency);
-        let entry = self
-            .raft
+        let node = self.router.route_read(&req.key).await.map_err(ggap_to_status)?;
+        let entry = node
             .read(&req.key, req.at_version, mode)
             .await
             .map_err(ggap_to_status)?;
@@ -59,13 +59,14 @@ impl<R: RaftNode> KvService for KvServiceImpl<R> {
         } else {
             Some(req.ttl_secs as i64 * 1_000_000_000)
         };
+        let node = self.router.route_write(&req.key).await.map_err(ggap_to_status)?;
         let cmd = KvCommand::Put {
             key: req.key,
             value: req.value,
             ttl_ns,
             expect_version: req.expect_version,
         };
-        let resp = self.raft.propose(cmd, mode).await.map_err(ggap_to_status)?;
+        let resp = node.propose(cmd, mode).await.map_err(ggap_to_status)?;
         match resp {
             ggap_types::KvResponse::Written { version } => Ok(Response::new(PutResponse {
                 header: Some(stub_header(self.node_id)),
@@ -88,8 +89,9 @@ impl<R: RaftNode> KvService for KvServiceImpl<R> {
             return Err(Status::invalid_argument("key must not be empty"));
         }
         let mode = proto_write_quorum(req.quorum);
+        let node = self.router.route_write(&req.key).await.map_err(ggap_to_status)?;
         let cmd = KvCommand::Delete { key: req.key };
-        let resp = self.raft.propose(cmd, mode).await.map_err(ggap_to_status)?;
+        let resp = node.propose(cmd, mode).await.map_err(ggap_to_status)?;
         match resp {
             ggap_types::KvResponse::Deleted { found } => Ok(Response::new(DeleteResponse {
                 header: Some(stub_header(self.node_id)),
@@ -102,7 +104,6 @@ impl<R: RaftNode> KvService for KvServiceImpl<R> {
 
     async fn scan(&self, request: Request<ScanRequest>) -> Result<Response<ScanResponse>, Status> {
         let req = request.into_inner();
-        // page_token bytes are the UTF-8 continuation key from the previous page.
         let start_key = if req.page_token.is_empty() {
             req.start_key.clone()
         } else {
@@ -110,8 +111,12 @@ impl<R: RaftNode> KvService for KvServiceImpl<R> {
                 .map_err(|_| Status::invalid_argument("invalid page_token: not valid UTF-8"))?
         };
         let mode = proto_read_consistency(req.consistency);
-        let (entries, continuation) = self
-            .raft
+        let node = self
+            .router
+            .route_scan(&start_key, &req.end_key)
+            .await
+            .map_err(ggap_to_status)?;
+        let (entries, continuation) = node
             .scan(&start_key, &req.end_key, req.limit, mode)
             .await
             .map_err(ggap_to_status)?;
@@ -140,13 +145,14 @@ impl<R: RaftNode> KvService for KvServiceImpl<R> {
         } else {
             Some(req.ttl_secs as i64 * 1_000_000_000)
         };
+        let node = self.router.route_write(&req.key).await.map_err(ggap_to_status)?;
         let cmd = KvCommand::Cas {
             key: req.key,
             expected: req.expected_value,
             new_value: req.new_value,
             ttl_ns,
         };
-        let resp = self.raft.propose(cmd, mode).await.map_err(ggap_to_status)?;
+        let resp = node.propose(cmd, mode).await.map_err(ggap_to_status)?;
         match resp {
             ggap_types::KvResponse::CasResult { success, current } => {
                 Ok(Response::new(CasResponse {

--- a/crates/ggap-server/src/kv_service.rs
+++ b/crates/ggap-server/src/kv_service.rs
@@ -33,7 +33,11 @@ impl KvService for KvServiceImpl {
             return Err(Status::invalid_argument("key must not be empty"));
         }
         let mode = proto_read_consistency(req.consistency);
-        let node = self.router.route_read(&req.key).await.map_err(ggap_to_status)?;
+        let node = self
+            .router
+            .route_read(&req.key)
+            .await
+            .map_err(ggap_to_status)?;
         let entry = node
             .read(&req.key, req.at_version, mode)
             .await
@@ -59,7 +63,11 @@ impl KvService for KvServiceImpl {
         } else {
             Some(req.ttl_secs as i64 * 1_000_000_000)
         };
-        let node = self.router.route_write(&req.key).await.map_err(ggap_to_status)?;
+        let node = self
+            .router
+            .route_write(&req.key)
+            .await
+            .map_err(ggap_to_status)?;
         let cmd = KvCommand::Put {
             key: req.key,
             value: req.value,
@@ -89,7 +97,11 @@ impl KvService for KvServiceImpl {
             return Err(Status::invalid_argument("key must not be empty"));
         }
         let mode = proto_write_quorum(req.quorum);
-        let node = self.router.route_write(&req.key).await.map_err(ggap_to_status)?;
+        let node = self
+            .router
+            .route_write(&req.key)
+            .await
+            .map_err(ggap_to_status)?;
         let cmd = KvCommand::Delete { key: req.key };
         let resp = node.propose(cmd, mode).await.map_err(ggap_to_status)?;
         match resp {
@@ -145,7 +157,11 @@ impl KvService for KvServiceImpl {
         } else {
             Some(req.ttl_secs as i64 * 1_000_000_000)
         };
-        let node = self.router.route_write(&req.key).await.map_err(ggap_to_status)?;
+        let node = self
+            .router
+            .route_write(&req.key)
+            .await
+            .map_err(ggap_to_status)?;
         let cmd = KvCommand::Cas {
             key: req.key,
             expected: req.expected_value,

--- a/crates/ggap-server/src/lib.rs
+++ b/crates/ggap-server/src/lib.rs
@@ -9,20 +9,21 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 
-use ggap_consensus::{ClusterNode, RaftNode};
+use ggap_consensus::{ShardRouter, SplitCoordinator};
 use ggap_proto::v1::{
     admin_service_server::AdminServiceServer, kv_service_server::KvServiceServer,
     raft_service_server::RaftServiceServer,
 };
+use ggap_storage::ShardMap;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 
 use admin_service::AdminServiceImpl;
 use kv_service::KvServiceImpl;
 use raft_service::RaftServiceImpl;
 
-pub async fn serve_client<R: RaftNode>(
+pub async fn serve_client(
     addr: SocketAddr,
-    raft: Arc<R>,
+    router: Arc<ShardRouter>,
     node_id: u64,
 ) -> anyhow::Result<()> {
     let reflection = ReflectionBuilder::configure()
@@ -31,7 +32,7 @@ pub async fn serve_client<R: RaftNode>(
         .expect("failed to build reflection service");
     tracing::info!(%addr, "client gRPC server starting");
     tonic::transport::Server::builder()
-        .add_service(KvServiceServer::new(KvServiceImpl::new(raft, node_id)))
+        .add_service(KvServiceServer::new(KvServiceImpl::new(router, node_id)))
         .add_service(reflection)
         .serve(addr)
         .await
@@ -39,12 +40,9 @@ pub async fn serve_client<R: RaftNode>(
 }
 
 /// Variant of [`serve_client`] that accepts a pre-bound [`TcpListener`].
-///
-/// Useful in tests where you need to know the bound port before initialising
-/// the Raft cluster (bind port 0, extract the address, then call this).
-pub async fn serve_client_with_listener<R: RaftNode>(
+pub async fn serve_client_with_listener(
     listener: TcpListener,
-    raft: Arc<R>,
+    router: Arc<ShardRouter>,
     node_id: u64,
 ) -> anyhow::Result<()> {
     let reflection = ReflectionBuilder::configure()
@@ -52,16 +50,18 @@ pub async fn serve_client_with_listener<R: RaftNode>(
         .build_v1()
         .expect("failed to build reflection service");
     tonic::transport::Server::builder()
-        .add_service(KvServiceServer::new(KvServiceImpl::new(raft, node_id)))
+        .add_service(KvServiceServer::new(KvServiceImpl::new(router, node_id)))
         .add_service(reflection)
         .serve_with_incoming(TcpListenerStream::new(listener))
         .await
         .map_err(Into::into)
 }
 
-pub async fn serve_cluster<CN: ClusterNode>(
+pub async fn serve_cluster(
     addr: SocketAddr,
-    cluster: Arc<CN>,
+    router: Arc<ShardRouter>,
+    split_coordinator: Arc<SplitCoordinator>,
+    shard_map: Arc<ShardMap>,
 ) -> anyhow::Result<()> {
     let reflection = ReflectionBuilder::configure()
         .register_encoded_file_descriptor_set(ggap_proto::FILE_DESCRIPTOR_SET)
@@ -69,8 +69,11 @@ pub async fn serve_cluster<CN: ClusterNode>(
         .expect("failed to build reflection service");
     tracing::info!(%addr, "cluster gRPC server starting");
     tonic::transport::Server::builder()
-        .add_service(RaftServiceServer::new(RaftServiceImpl::new(cluster)))
-        .add_service(AdminServiceServer::new(AdminServiceImpl))
+        .add_service(RaftServiceServer::new(RaftServiceImpl::new(router)))
+        .add_service(AdminServiceServer::new(AdminServiceImpl::new(
+            split_coordinator,
+            shard_map,
+        )))
         .add_service(reflection)
         .serve(addr)
         .await
@@ -78,17 +81,22 @@ pub async fn serve_cluster<CN: ClusterNode>(
 }
 
 /// Variant of [`serve_cluster`] that accepts a pre-bound [`TcpListener`].
-pub async fn serve_cluster_with_listener<CN: ClusterNode>(
+pub async fn serve_cluster_with_listener(
     listener: TcpListener,
-    cluster: Arc<CN>,
+    router: Arc<ShardRouter>,
+    split_coordinator: Arc<SplitCoordinator>,
+    shard_map: Arc<ShardMap>,
 ) -> anyhow::Result<()> {
     let reflection = ReflectionBuilder::configure()
         .register_encoded_file_descriptor_set(ggap_proto::FILE_DESCRIPTOR_SET)
         .build_v1()
         .expect("failed to build reflection service");
     tonic::transport::Server::builder()
-        .add_service(RaftServiceServer::new(RaftServiceImpl::new(cluster)))
-        .add_service(AdminServiceServer::new(AdminServiceImpl))
+        .add_service(RaftServiceServer::new(RaftServiceImpl::new(router)))
+        .add_service(AdminServiceServer::new(AdminServiceImpl::new(
+            split_coordinator,
+            shard_map,
+        )))
         .add_service(reflection)
         .serve_with_incoming(TcpListenerStream::new(listener))
         .await

--- a/crates/ggap-server/src/raft_service.rs
+++ b/crates/ggap-server/src/raft_service.rs
@@ -1,40 +1,55 @@
 use std::sync::Arc;
 
-use ggap_consensus::ClusterNode;
+use ggap_consensus::{ClusterNode, ShardRouter};
 use ggap_proto::v1::{raft_service_server::RaftService, RaftMessage};
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::convert::ggap_to_status;
 
-pub struct RaftServiceImpl<CN> {
-    cluster: Arc<CN>,
+pub struct RaftServiceImpl {
+    router: Arc<ShardRouter>,
 }
 
-impl<CN: ClusterNode> RaftServiceImpl<CN> {
-    pub fn new(cluster: Arc<CN>) -> Self {
-        RaftServiceImpl { cluster }
+impl RaftServiceImpl {
+    pub fn new(router: Arc<ShardRouter>) -> Self {
+        RaftServiceImpl { router }
     }
 }
 
 #[tonic::async_trait]
-impl<CN: ClusterNode> RaftService for RaftServiceImpl<CN> {
+impl RaftService for RaftServiceImpl {
     async fn append_entries(
         &self,
         request: Request<RaftMessage>,
     ) -> Result<Response<RaftMessage>, Status> {
-        let payload = request.into_inner().data;
-        let out = self
-            .cluster
-            .append_entries(payload)
+        let msg = request.into_inner();
+        let cluster = self
+            .router
+            .get_cluster(msg.shard_id)
+            .await
+            .ok_or_else(|| Status::not_found(format!("shard {} not found", msg.shard_id)))?;
+        let out = cluster
+            .append_entries(msg.data)
             .await
             .map_err(ggap_to_status)?;
-        Ok(Response::new(RaftMessage { data: out }))
+        Ok(Response::new(RaftMessage {
+            shard_id: msg.shard_id,
+            data: out,
+        }))
     }
 
     async fn vote(&self, request: Request<RaftMessage>) -> Result<Response<RaftMessage>, Status> {
-        let payload = request.into_inner().data;
-        let out = self.cluster.vote(payload).await.map_err(ggap_to_status)?;
-        Ok(Response::new(RaftMessage { data: out }))
+        let msg = request.into_inner();
+        let cluster = self
+            .router
+            .get_cluster(msg.shard_id)
+            .await
+            .ok_or_else(|| Status::not_found(format!("shard {} not found", msg.shard_id)))?;
+        let out = cluster.vote(msg.data).await.map_err(ggap_to_status)?;
+        Ok(Response::new(RaftMessage {
+            shard_id: msg.shard_id,
+            data: out,
+        }))
     }
 
     async fn install_snapshot(
@@ -43,10 +58,16 @@ impl<CN: ClusterNode> RaftService for RaftServiceImpl<CN> {
     ) -> Result<Response<RaftMessage>, Status> {
         let mut stream = request.into_inner();
         let mut last_resp: Option<Vec<u8>> = None;
+        let mut shard_id = 0u64;
 
         while let Some(msg) = stream.message().await? {
-            let out = self
-                .cluster
+            shard_id = msg.shard_id;
+            let cluster = self
+                .router
+                .get_cluster(msg.shard_id)
+                .await
+                .ok_or_else(|| Status::not_found(format!("shard {} not found", msg.shard_id)))?;
+            let out = cluster
                 .install_snapshot(msg.data)
                 .await
                 .map_err(ggap_to_status)?;
@@ -54,6 +75,6 @@ impl<CN: ClusterNode> RaftService for RaftServiceImpl<CN> {
         }
 
         let data = last_resp.unwrap_or_default();
-        Ok(Response::new(RaftMessage { data }))
+        Ok(Response::new(RaftMessage { shard_id, data }))
     }
 }

--- a/crates/ggap-server/src/raft_service.rs
+++ b/crates/ggap-server/src/raft_service.rs
@@ -62,11 +62,10 @@ impl RaftService for RaftServiceImpl {
 
         while let Some(msg) = stream.message().await? {
             shard_id = msg.shard_id;
-            let cluster = self
-                .router
-                .get_cluster(msg.shard_id)
-                .await
-                .ok_or_else(|| Status::not_found(format!("shard {} not found", msg.shard_id)))?;
+            let cluster =
+                self.router.get_cluster(msg.shard_id).await.ok_or_else(|| {
+                    Status::not_found(format!("shard {} not found", msg.shard_id))
+                })?;
             let out = cluster
                 .install_snapshot(msg.data)
                 .await

--- a/crates/ggap-server/tests/split_single_node.rs
+++ b/crates/ggap-server/tests/split_single_node.rs
@@ -15,7 +15,7 @@ use tempfile::TempDir;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator,
+    OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
 use ggap_storage::fjall::{FjallStateMachine, FjallStore};
 use ggap_storage::traits::StateMachineStore;
@@ -64,17 +64,17 @@ async fn setup() -> TestSetup {
     let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
     router.add_shard(0, node, cluster).await;
 
-    let split_coordinator = Arc::new(SplitCoordinator::new(
-        router.clone(),
-        shard_map.clone(),
+    let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
+        router: router.clone(),
+        shard_map: shard_map.clone(),
         store,
-        fsm.clone(),
-        1,
-        "127.0.0.1:0".into(), // unused for single-node
-        50,
-        150,
-        300,
-    ));
+        fsm: fsm.clone(),
+        node_id: 1,
+        cluster_addr: "127.0.0.1:0".into(), // unused for single-node
+        heartbeat_ms: 50,
+        election_min_ms: 150,
+        election_max_ms: 300,
+    }));
 
     TestSetup {
         router,

--- a/crates/ggap-server/tests/split_single_node.rs
+++ b/crates/ggap-server/tests/split_single_node.rs
@@ -1,0 +1,348 @@
+//! Single-node shard split integration test.
+//!
+//! Verifies that splitting a shard correctly partitions data and routes
+//! reads/writes to the correct shard after the split.
+//!
+//! Run with:
+//!   cargo test -p ggap-server --test split_single_node -- --nocapture
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::{BasicNode, ServerState};
+use tempfile::TempDir;
+
+use ggap_consensus::{
+    build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
+    OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator,
+};
+use ggap_storage::fjall::{FjallStateMachine, FjallStore};
+use ggap_storage::traits::StateMachineStore;
+use ggap_storage::ShardMap;
+use ggap_types::{KvCommand, KvResponse, ReadMode, WriteMode};
+
+/// Helper to set up a single-node cluster with one shard.
+struct TestSetup {
+    router: Arc<ShardRouter>,
+    shard_map: Arc<ShardMap>,
+    split_coordinator: Arc<SplitCoordinator>,
+    fsm: Arc<FjallStateMachine>,
+    raft: Arc<GgapRaft>,
+    _tempdir: TempDir,
+}
+
+async fn setup() -> TestSetup {
+    let tempdir = TempDir::new().unwrap();
+    let store = FjallStore::open(tempdir.path()).unwrap();
+    let fsm = Arc::new(FjallStateMachine::new(store.clone()));
+    let log_store = GgapLogStorage::new(store.clone(), 0);
+    let sm = GgapStateMachine::new(fsm.clone(), 0);
+    let cfg = build_raft_config(50, 150, 300);
+    let raft = Arc::new(
+        GgapRaft::new(1, cfg, GgapNetworkFactory::new(0), log_store, sm)
+            .await
+            .unwrap(),
+    );
+
+    // Initialize as single-node cluster.
+    let mut members = BTreeMap::new();
+    members.insert(1u64, BasicNode::default());
+    raft.initialize(members).await.unwrap();
+
+    // Wait for leader.
+    raft.wait(Some(Duration::from_secs(5)))
+        .state(ServerState::Leader, "become leader")
+        .await
+        .unwrap();
+
+    let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
+    shard_map.initialize_default().await.unwrap();
+
+    let router = Arc::new(ShardRouter::new(shard_map.clone()));
+    let node = Arc::new(OpenRaftNode::new(raft.clone(), fsm.clone(), 0, 1));
+    let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
+    router.add_shard(0, node, cluster).await;
+
+    let split_coordinator = Arc::new(SplitCoordinator::new(
+        router.clone(),
+        shard_map.clone(),
+        store,
+        fsm.clone(),
+        1,
+        "127.0.0.1:0".into(), // unused for single-node
+        50,
+        150,
+        300,
+    ));
+
+    TestSetup {
+        router,
+        shard_map,
+        split_coordinator,
+        fsm,
+        raft,
+        _tempdir: tempdir,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn split_partitions_data_correctly() {
+    let s = setup().await;
+
+    // Write keys across the alphabet.
+    let keys = ["apple", "banana", "cherry", "mango", "orange", "zebra"];
+    for key in &keys {
+        let resp = s
+            .raft
+            .client_write(KvCommand::Put {
+                key: key.to_string(),
+                value: format!("val-{key}").into_bytes(),
+                ttl_ns: None,
+                expect_version: 0,
+            })
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp.data, KvResponse::Written { .. }),
+            "failed to write {key}"
+        );
+    }
+
+    // Verify all 6 keys are in shard 0.
+    assert_eq!(s.shard_map.all_shards().await.len(), 1);
+
+    // Split shard 0 at "m" → shard 0: ["", "m"), shard 1: ["m", "")
+    let new_shard_id = s.split_coordinator.split(0, "m").await.unwrap();
+    assert_eq!(new_shard_id, 1);
+
+    // Verify ShardMap has 2 shards now.
+    let shards = s.shard_map.all_shards().await;
+    assert_eq!(shards.len(), 2);
+
+    let shard0 = s.shard_map.get_shard(0).await.unwrap();
+    assert_eq!(shard0.range.start, "");
+    assert_eq!(shard0.range.end, "m");
+
+    let shard1 = s.shard_map.get_shard(1).await.unwrap();
+    assert_eq!(shard1.range.start, "m");
+    assert_eq!(shard1.range.end, "");
+
+    // Verify routing: keys < "m" route to shard 0.
+    for key in &["apple", "banana", "cherry"] {
+        let node = s.router.route_read(key).await.unwrap();
+        assert_eq!(node.shard_id(), 0, "key '{key}' should route to shard 0");
+    }
+
+    // Verify routing: keys >= "m" route to shard 1.
+    for key in &["mango", "orange", "zebra"] {
+        let node = s.router.route_read(key).await.unwrap();
+        assert_eq!(node.shard_id(), 1, "key '{key}' should route to shard 1");
+    }
+
+    // Verify data: keys in shard 0's storage.
+    for key in &["apple", "banana", "cherry"] {
+        let entry = s.fsm.get(0, key, 0).await.unwrap();
+        assert!(
+            entry.is_some(),
+            "key '{key}' should exist in shard 0 storage"
+        );
+    }
+    // Keys >= "m" should NOT be in shard 0's storage anymore.
+    for key in &["mango", "orange", "zebra"] {
+        let entry = s.fsm.get(0, key, 0).await.unwrap();
+        assert!(
+            entry.is_none(),
+            "key '{key}' should NOT exist in shard 0 storage"
+        );
+    }
+
+    // Verify data: keys in shard 1's storage.
+    for key in &["mango", "orange", "zebra"] {
+        let entry = s.fsm.get(1, key, 0).await.unwrap();
+        assert!(
+            entry.is_some(),
+            "key '{key}' should exist in shard 1 storage"
+        );
+        let e = entry.unwrap();
+        assert_eq!(e.value, format!("val-{key}").into_bytes());
+    }
+    // Keys < "m" should NOT be in shard 1's storage.
+    for key in &["apple", "banana", "cherry"] {
+        let entry = s.fsm.get(1, key, 0).await.unwrap();
+        assert!(
+            entry.is_none(),
+            "key '{key}' should NOT exist in shard 1 storage"
+        );
+    }
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn writes_after_split_route_correctly() {
+    let s = setup().await;
+
+    // Write initial data.
+    s.raft
+        .client_write(KvCommand::Put {
+            key: "alpha".into(),
+            value: b"1".to_vec(),
+            ttl_ns: None,
+            expect_version: 0,
+        })
+        .await
+        .unwrap();
+    s.raft
+        .client_write(KvCommand::Put {
+            key: "zulu".into(),
+            value: b"2".to_vec(),
+            ttl_ns: None,
+            expect_version: 0,
+        })
+        .await
+        .unwrap();
+
+    // Split at "m".
+    s.split_coordinator.split(0, "m").await.unwrap();
+
+    // Write new keys through the router (simulating gRPC path).
+    let node_d = s.router.route_write("delta").await.unwrap();
+    assert_eq!(node_d.shard_id(), 0);
+    let resp = node_d
+        .propose(
+            KvCommand::Put {
+                key: "delta".into(),
+                value: b"new-lower".to_vec(),
+                ttl_ns: None,
+                expect_version: 0,
+            },
+            WriteMode::Majority,
+        )
+        .await
+        .unwrap();
+    assert!(matches!(resp, KvResponse::Written { .. }));
+
+    let node_p = s.router.route_write("papa").await.unwrap();
+    assert_eq!(node_p.shard_id(), 1);
+    let resp = node_p
+        .propose(
+            KvCommand::Put {
+                key: "papa".into(),
+                value: b"new-upper".to_vec(),
+                ttl_ns: None,
+                expect_version: 0,
+            },
+            WriteMode::Majority,
+        )
+        .await
+        .unwrap();
+    assert!(matches!(resp, KvResponse::Written { .. }));
+
+    // Verify: "delta" in shard 0, "papa" in shard 1.
+    let delta = s.fsm.get(0, "delta", 0).await.unwrap().unwrap();
+    assert_eq!(delta.value, b"new-lower");
+
+    let papa = s.fsm.get(1, "papa", 0).await.unwrap().unwrap();
+    assert_eq!(papa.value, b"new-upper");
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn split_rejects_invalid_key() {
+    let s = setup().await;
+
+    // Split with empty key should fail.
+    let err = s.split_coordinator.split(0, "").await;
+    assert!(err.is_err());
+
+    // Split non-existent shard should fail.
+    let err = s.split_coordinator.split(99, "m").await;
+    assert!(err.is_err());
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn double_split_works() {
+    let s = setup().await;
+
+    // Write keys.
+    for key in ["a", "d", "g", "m", "p", "z"] {
+        s.raft
+            .client_write(KvCommand::Put {
+                key: key.into(),
+                value: key.as_bytes().to_vec(),
+                ttl_ns: None,
+                expect_version: 0,
+            })
+            .await
+            .unwrap();
+    }
+
+    // First split at "m": shard 0 = ["", "m"), shard 1 = ["m", "")
+    let shard1 = s.split_coordinator.split(0, "m").await.unwrap();
+    assert_eq!(shard1, 1);
+
+    // Second split at "d" on shard 0: shard 0 = ["", "d"), shard 2 = ["d", "m")
+    let shard2 = s.split_coordinator.split(0, "d").await.unwrap();
+    assert_eq!(shard2, 2);
+
+    // Verify 3 shards.
+    assert_eq!(s.shard_map.all_shards().await.len(), 3);
+
+    // Check routing.
+    assert_eq!(s.router.route_read("a").await.unwrap().shard_id(), 0);
+    assert_eq!(s.router.route_read("d").await.unwrap().shard_id(), 2);
+    assert_eq!(s.router.route_read("g").await.unwrap().shard_id(), 2);
+    assert_eq!(s.router.route_read("m").await.unwrap().shard_id(), 1);
+    assert_eq!(s.router.route_read("z").await.unwrap().shard_id(), 1);
+
+    // Check data in correct shards.
+    assert!(s.fsm.get(0, "a", 0).await.unwrap().is_some());
+    assert!(s.fsm.get(0, "d", 0).await.unwrap().is_none()); // moved to shard 2
+    assert!(s.fsm.get(2, "d", 0).await.unwrap().is_some());
+    assert!(s.fsm.get(2, "g", 0).await.unwrap().is_some());
+    assert!(s.fsm.get(1, "m", 0).await.unwrap().is_some());
+    assert!(s.fsm.get(1, "z", 0).await.unwrap().is_some());
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_within_shard_works_after_split() {
+    let s = setup().await;
+
+    // Write some keys.
+    for key in ["a", "b", "c", "x", "y", "z"] {
+        s.raft
+            .client_write(KvCommand::Put {
+                key: key.into(),
+                value: key.as_bytes().to_vec(),
+                ttl_ns: None,
+                expect_version: 0,
+            })
+            .await
+            .unwrap();
+    }
+
+    // Split at "m".
+    s.split_coordinator.split(0, "m").await.unwrap();
+
+    // Scan within shard 0 (keys < "m").
+    let node0 = s.router.route_scan("a", "m").await.unwrap();
+    assert_eq!(node0.shard_id(), 0);
+    let (entries, _) = node0.scan("a", "m", 100, ReadMode::Eventual).await.unwrap();
+    let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
+    assert_eq!(keys, vec!["a", "b", "c"]);
+
+    // Scan within shard 1 (keys >= "m").
+    let node1 = s.router.route_scan("m", "").await.unwrap();
+    assert_eq!(node1.shard_id(), 1);
+    let (entries, _) = node1.scan("m", "", 100, ReadMode::Eventual).await.unwrap();
+    let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
+    assert_eq!(keys, vec!["x", "y", "z"]);
+
+    s.raft.shutdown().await.unwrap();
+}

--- a/crates/ggap-server/tests/three_node_cluster.rs
+++ b/crates/ggap-server/tests/three_node_cluster.rs
@@ -7,9 +7,6 @@
 //!
 //! Run with:
 //!   cargo test -p ggap-server --test three_node_cluster -- --nocapture
-//!
-//! Benchmark with (once a bench harness is added):
-//!   cargo bench -p ggap-server
 
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
@@ -22,11 +19,12 @@ use tokio::net::TcpListener;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, RaftNode,
+    OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator,
 };
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener};
 use ggap_storage::fjall::{FjallStateMachine, FjallStore};
 use ggap_storage::traits::StateMachineStore;
+use ggap_storage::ShardMap;
 use ggap_types::{KvCommand, KvResponse, ReadMode};
 
 // ---------------------------------------------------------------------------
@@ -54,7 +52,7 @@ async fn start_node(id: u64) -> TestNode {
     // Fast timeouts so tests finish quickly.
     let cfg = build_raft_config(50, 150, 300);
     let raft = Arc::new(
-        GgapRaft::new(id, cfg, GgapNetworkFactory, log_store, sm)
+        GgapRaft::new(id, cfg, GgapNetworkFactory::new(0), log_store, sm)
             .await
             .unwrap_or_else(|e| panic!("node {id}: raft init failed: {e}")),
     );
@@ -64,22 +62,41 @@ async fn start_node(id: u64) -> TestNode {
     let cluster_addr = cluster_listener.local_addr().unwrap();
     let client_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
 
-    let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
     let raft_node = Arc::new(OpenRaftNode::new(raft.clone(), fsm.clone(), 0, id));
+    let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
+
+    // Build a single-shard router for this node.
+    let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
+    shard_map.initialize_default().await.unwrap();
+    let router = Arc::new(ShardRouter::new(shard_map.clone()));
+    router.add_shard(0, raft_node.clone(), cluster).await;
+
+    let split_coordinator = Arc::new(SplitCoordinator::new(
+        router.clone(),
+        shard_map.clone(),
+        store,
+        fsm.clone(),
+        id,
+        cluster_addr.to_string(),
+        50,
+        150,
+        300,
+    ));
 
     let mut handles = Vec::new();
 
-    let c = cluster.clone();
+    let r = router.clone();
+    let sc = split_coordinator.clone();
+    let sm2 = shard_map.clone();
     handles.push(tokio::spawn(async move {
-        if let Err(e) = serve_cluster_with_listener(cluster_listener, c).await {
-            // Server exits when the listener is closed — log only genuine errors.
+        if let Err(e) = serve_cluster_with_listener(cluster_listener, r, sc, sm2).await {
             eprintln!("node {id} cluster server: {e}");
         }
     }));
 
-    let n = raft_node.clone();
+    let r = router.clone();
     handles.push(tokio::spawn(async move {
-        if let Err(e) = serve_client_with_listener(client_listener, n, id).await {
+        if let Err(e) = serve_client_with_listener(client_listener, r, id).await {
             eprintln!("node {id} client server: {e}");
         }
     }));
@@ -232,8 +249,7 @@ async fn three_node_leader_election_and_basic_ops() {
     assert_eq!(entry.value, b"world");
 
     // Verify replication: all nodes (including followers) carry the data in
-    // their FSMs.  Lease-based linearizable reads from followers are Phase 5;
-    // for now read directly from the FSM after confirmed convergence.
+    // their FSMs.
     for node in &cluster.nodes {
         let entry = node
             .fsm

--- a/crates/ggap-server/tests/three_node_cluster.rs
+++ b/crates/ggap-server/tests/three_node_cluster.rs
@@ -19,7 +19,7 @@ use tokio::net::TcpListener;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator,
+    OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener};
 use ggap_storage::fjall::{FjallStateMachine, FjallStore};
@@ -71,17 +71,17 @@ async fn start_node(id: u64) -> TestNode {
     let router = Arc::new(ShardRouter::new(shard_map.clone()));
     router.add_shard(0, raft_node.clone(), cluster).await;
 
-    let split_coordinator = Arc::new(SplitCoordinator::new(
-        router.clone(),
-        shard_map.clone(),
+    let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
+        router: router.clone(),
+        shard_map: shard_map.clone(),
         store,
-        fsm.clone(),
-        id,
-        cluster_addr.to_string(),
-        50,
-        150,
-        300,
-    ));
+        fsm: fsm.clone(),
+        node_id: id,
+        cluster_addr: cluster_addr.to_string(),
+        heartbeat_ms: 50,
+        election_min_ms: 150,
+        election_max_ms: 300,
+    }));
 
     let mut handles = Vec::new();
 

--- a/crates/ggap-storage/src/fjall.rs
+++ b/crates/ggap-storage/src/fjall.rs
@@ -887,20 +887,18 @@ impl FjallStateMachine {
             let history_keys: Vec<Vec<u8>> = store
                 .history
                 .range(shard_start.clone()..shard_end.clone())
-                .filter_map(|g| {
-                    match g.into_inner().map_err(fjall_err) {
-                        Ok((k, _)) => {
-                            let raw = &k[8..];
-                            if let Some(null_pos) = raw.iter().position(|&b| b == 0) {
-                                let user_key_bytes = &raw[..null_pos];
-                                if user_key_bytes >= from_key.as_bytes() {
-                                    return Some(Ok(k.to_vec()));
-                                }
+                .filter_map(|g| match g.into_inner().map_err(fjall_err) {
+                    Ok((k, _)) => {
+                        let raw = &k[8..];
+                        if let Some(null_pos) = raw.iter().position(|&b| b == 0) {
+                            let user_key_bytes = &raw[..null_pos];
+                            if user_key_bytes >= from_key.as_bytes() {
+                                return Some(Ok(k.to_vec()));
                             }
-                            None
                         }
-                        Err(e) => Some(Err(e)),
+                        None
                     }
+                    Err(e) => Some(Err(e)),
                 })
                 .collect::<Result<_, _>>()?;
 

--- a/crates/ggap-storage/src/fjall.rs
+++ b/crates/ggap-storage/src/fjall.rs
@@ -759,6 +759,188 @@ impl StateMachineStore for FjallStateMachine {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Split helpers on FjallStateMachine
+// ---------------------------------------------------------------------------
+
+impl FjallStateMachine {
+    /// Build a snapshot containing only keys `>= split_key` within the shard.
+    /// Used during range splitting to extract the upper half of a shard.
+    pub async fn build_partial_snapshot(
+        &self,
+        shard_id: ShardId,
+        split_key: &str,
+    ) -> Result<SnapshotContents, GgapError> {
+        let store = self.store.clone();
+        let split_key = split_key.to_string();
+        tokio::task::spawn_blocking(move || -> Result<SnapshotContents, GgapError> {
+            let start = data_key(shard_id, &split_key);
+            let shard_end = data_shard_end(shard_id).to_vec();
+
+            let data: Vec<(String, KvEntry)> = store
+                .data
+                .range(start..shard_end.clone())
+                .map(|g| {
+                    g.into_inner().map_err(fjall_err).and_then(|(k, v)| {
+                        let user_key = String::from_utf8(k[8..].to_vec())
+                            .map_err(|e| GgapError::Storage(e.to_string()))?;
+                        Ok((user_key, decode::<KvEntry>(&v)?))
+                    })
+                })
+                .collect::<Result<_, _>>()?;
+
+            // History: scan entire shard and filter by user key >= split_key
+            let shard_start = shard_id.to_be_bytes().to_vec();
+            let history: Vec<((String, u64), KvEntry)> = store
+                .history
+                .range(shard_start..shard_end)
+                .map(|g| {
+                    g.into_inner().map_err(fjall_err).and_then(|(k, v)| {
+                        let raw = &k[8..];
+                        let null_pos = raw.iter().position(|&b| b == 0).ok_or_else(|| {
+                            GgapError::Storage("malformed history key: missing null byte".into())
+                        })?;
+                        let user_key = String::from_utf8(raw[..null_pos].to_vec())
+                            .map_err(|e| GgapError::Storage(e.to_string()))?;
+                        let version = u64::from_be_bytes(
+                            raw[null_pos + 1..null_pos + 9].try_into().map_err(|_| {
+                                GgapError::Storage("malformed history key: short version".into())
+                            })?,
+                        );
+                        Ok(((user_key, version), decode::<KvEntry>(&v)?))
+                    })
+                })
+                .filter(|r| match r {
+                    Ok(((ref user_key, _), _)) => user_key.as_str() >= split_key.as_str(),
+                    Err(_) => true, // propagate errors
+                })
+                .collect::<Result<_, _>>()?;
+
+            Ok(SnapshotContents { data, history })
+        })
+        .await
+        .map_err(|e| GgapError::Storage(e.to_string()))?
+    }
+
+    /// Install a partial snapshot into a new shard, writing keys with the
+    /// new shard_id prefix. Also copies TTL index entries.
+    pub async fn install_partial_snapshot(
+        &self,
+        new_shard_id: ShardId,
+        contents: &SnapshotContents,
+    ) -> Result<(), GgapError> {
+        let store = self.store.clone();
+        let data = contents.data.clone();
+        let history = contents.history.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), GgapError> {
+            let mut batch = store.db.batch();
+            for (user_key, entry) in &data {
+                batch.insert(
+                    &store.data,
+                    data_key(new_shard_id, user_key),
+                    encode(entry)?,
+                );
+                if let Some(expires_at_ns) = entry.expires_at_ns {
+                    batch.insert(
+                        &store.ttl_index,
+                        ttl_index_key(new_shard_id, expires_at_ns, user_key),
+                        Vec::new(),
+                    );
+                }
+            }
+            for ((user_key, version), entry) in &history {
+                batch.insert(
+                    &store.history,
+                    history_key(new_shard_id, user_key, *version),
+                    encode(entry)?,
+                );
+            }
+            batch.commit().map_err(fjall_err)
+        })
+        .await
+        .map_err(|e| GgapError::Storage(e.to_string()))?
+    }
+
+    /// Delete all keys `>= from_key` from a shard's data, history, and
+    /// ttl_index partitions. Used after a split to remove the upper half
+    /// from the source shard.
+    pub async fn delete_range_from(
+        &self,
+        shard_id: ShardId,
+        from_key: &str,
+    ) -> Result<(), GgapError> {
+        let store = self.store.clone();
+        let from_key = from_key.to_string();
+        tokio::task::spawn_blocking(move || -> Result<(), GgapError> {
+            let start = data_key(shard_id, &from_key);
+            let shard_end = data_shard_end(shard_id).to_vec();
+
+            // Collect data keys to delete
+            let data_keys: Vec<Vec<u8>> = store
+                .data
+                .range(start..shard_end.clone())
+                .map(|g| g.into_inner().map(|(k, _)| k.to_vec()).map_err(fjall_err))
+                .collect::<Result<_, _>>()?;
+
+            // Collect history keys to delete (filter by user key)
+            let shard_start = shard_id.to_be_bytes().to_vec();
+            let history_keys: Vec<Vec<u8>> = store
+                .history
+                .range(shard_start.clone()..shard_end.clone())
+                .filter_map(|g| {
+                    match g.into_inner().map_err(fjall_err) {
+                        Ok((k, _)) => {
+                            let raw = &k[8..];
+                            if let Some(null_pos) = raw.iter().position(|&b| b == 0) {
+                                let user_key_bytes = &raw[..null_pos];
+                                if user_key_bytes >= from_key.as_bytes() {
+                                    return Some(Ok(k.to_vec()));
+                                }
+                            }
+                            None
+                        }
+                        Err(e) => Some(Err(e)),
+                    }
+                })
+                .collect::<Result<_, _>>()?;
+
+            // Collect TTL index keys to delete (filter by user key)
+            let ttl_keys: Vec<Vec<u8>> = store
+                .ttl_index
+                .range(shard_start..shard_end)
+                .filter_map(|g| {
+                    match g.into_inner().map_err(fjall_err) {
+                        Ok((k, _)) => {
+                            // TTL key: shard(8) ++ expires_at_ns(8) ++ key_utf8
+                            let user_key_bytes = &k[16..];
+                            if user_key_bytes >= from_key.as_bytes() {
+                                Some(Ok(k.to_vec()))
+                            } else {
+                                None
+                            }
+                        }
+                        Err(e) => Some(Err(e)),
+                    }
+                })
+                .collect::<Result<_, _>>()?;
+
+            let mut batch = store.db.batch();
+            for k in data_keys {
+                batch.remove(&store.data, k);
+            }
+            for k in history_keys {
+                batch.remove(&store.history, k);
+            }
+            for k in ttl_keys {
+                batch.remove(&store.ttl_index, k);
+            }
+            batch.commit().map_err(fjall_err)
+        })
+        .await
+        .map_err(|e| GgapError::Storage(e.to_string()))?
+    }
+}
+
 /// Compact history for `key`: if there are more than `max_history` versions,
 /// delete the oldest ones. The prefix iterator returns versions in ascending
 /// order (big-endian u64), so the first entries are the oldest.

--- a/crates/ggap-storage/src/lib.rs
+++ b/crates/ggap-storage/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod fjall;
 pub mod keys;
 pub mod mem;
+pub mod shard_map;
 pub mod traits;
 pub mod ttl;
 pub mod types;
 
+pub use shard_map::ShardMap;
 pub use traits::{LogStorage, StateMachineStore};
-pub use types::{LogEntry, LogPayload, LogState, Snapshot, SnapshotMeta, Vote};
+pub use types::{LogEntry, LogPayload, LogState, Snapshot, SnapshotContents, SnapshotMeta, Vote};

--- a/crates/ggap-storage/src/shard_map.rs
+++ b/crates/ggap-storage/src/shard_map.rs
@@ -1,0 +1,235 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use ggap_types::{GgapError, KeyRange, ShardId, ShardInfo, ShardState};
+
+use crate::fjall::FjallStore;
+use crate::keys::meta_key;
+
+/// Sentinel shard_id used as the prefix for ShardMap metadata in the `meta`
+/// keyspace. This must never collide with a real shard_id.
+const SHARD_MAP_PREFIX: ShardId = u64::MAX;
+
+fn shard_map_key(shard_id: ShardId) -> Vec<u8> {
+    // meta_key(SHARD_MAP_PREFIX, "shard:XXXX") where XXXX is be_u64(shard_id)
+    let label = format!("shard:{}", shard_id);
+    meta_key(SHARD_MAP_PREFIX, &label)
+}
+
+fn encode<T: serde::Serialize>(val: &T) -> Result<Vec<u8>, GgapError> {
+    bincode::serde::encode_to_vec(val, bincode::config::standard())
+        .map_err(|e| GgapError::Storage(e.to_string()))
+}
+
+fn decode<T: for<'de> serde::Deserialize<'de>>(bytes: &[u8]) -> Result<T, GgapError> {
+    bincode::serde::decode_from_slice(bytes, bincode::config::standard())
+        .map(|(v, _)| v)
+        .map_err(|e| GgapError::Storage(e.to_string()))
+}
+
+/// Persistent shard-to-range mapping backed by the `meta` keyspace of fjall.
+///
+/// The ShardMap tracks which `ShardId` owns which `KeyRange`. It keeps an
+/// in-memory cache that is loaded on startup and updated on mutations.
+pub struct ShardMap {
+    store: Arc<FjallStore>,
+    shards: RwLock<BTreeMap<ShardId, ShardInfo>>,
+}
+
+impl ShardMap {
+    /// Load all shard entries from storage and build the in-memory cache.
+    pub fn load(store: Arc<FjallStore>) -> Result<Self, GgapError> {
+        let prefix = SHARD_MAP_PREFIX.to_be_bytes().to_vec();
+        let mut shards = BTreeMap::new();
+
+        for guard in store.meta.prefix(&prefix) {
+            let (_, v) = guard
+                .into_inner()
+                .map_err(|e| GgapError::Storage(e.to_string()))?;
+            let info = decode::<ShardInfo>(&v)?;
+            shards.insert(info.shard_id, info);
+        }
+
+        Ok(ShardMap {
+            store,
+            shards: RwLock::new(shards),
+        })
+    }
+
+    /// If no shards exist, create shard 0 with the full key range.
+    pub async fn initialize_default(&self) -> Result<(), GgapError> {
+        let mut shards = self.shards.write().await;
+        if shards.is_empty() {
+            let info = ShardInfo {
+                shard_id: 0,
+                range: KeyRange {
+                    start: String::new(),
+                    end: String::new(),
+                },
+                state: ShardState::Active,
+            };
+            self.persist_shard(&info)?;
+            shards.insert(0, info);
+        }
+        Ok(())
+    }
+
+    /// Look up which shard owns a given key.
+    pub async fn lookup_shard(&self, key: &str) -> Option<ShardInfo> {
+        let shards = self.shards.read().await;
+        shards.values().find(|s| s.range.contains(key)).cloned()
+    }
+
+    /// Get info for a specific shard.
+    pub async fn get_shard(&self, shard_id: ShardId) -> Option<ShardInfo> {
+        self.shards.read().await.get(&shard_id).cloned()
+    }
+
+    /// Persist a shard info entry (insert or update).
+    pub async fn put_shard(&self, info: ShardInfo) -> Result<(), GgapError> {
+        self.persist_shard(&info)?;
+        self.shards.write().await.insert(info.shard_id, info);
+        Ok(())
+    }
+
+    /// Remove a shard entry.
+    pub async fn remove_shard(&self, shard_id: ShardId) -> Result<(), GgapError> {
+        self.store
+            .meta
+            .remove(shard_map_key(shard_id))
+            .map_err(|e| GgapError::Storage(e.to_string()))?;
+        self.shards.write().await.remove(&shard_id);
+        Ok(())
+    }
+
+    /// Return all shard infos.
+    pub async fn all_shards(&self) -> Vec<ShardInfo> {
+        self.shards.read().await.values().cloned().collect()
+    }
+
+    /// Allocate the next shard_id (max existing + 1).
+    pub async fn next_shard_id(&self) -> ShardId {
+        let shards = self.shards.read().await;
+        shards.keys().max().map(|m| m + 1).unwrap_or(0)
+    }
+
+    fn persist_shard(&self, info: &ShardInfo) -> Result<(), GgapError> {
+        let key = shard_map_key(info.shard_id);
+        let val = encode(info)?;
+        self.store
+            .meta
+            .insert(key, val)
+            .map_err(|e| GgapError::Storage(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn open_store() -> (TempDir, Arc<FjallStore>) {
+        let dir = TempDir::new().unwrap();
+        let store = FjallStore::open(dir.path()).unwrap();
+        (dir, store)
+    }
+
+    #[tokio::test]
+    async fn initialize_default_creates_shard_zero() {
+        let (_dir, store) = open_store();
+        let map = ShardMap::load(store).unwrap();
+        map.initialize_default().await.unwrap();
+
+        let shards = map.all_shards().await;
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].shard_id, 0);
+        assert_eq!(shards[0].range.start, "");
+        assert_eq!(shards[0].range.end, "");
+        assert_eq!(shards[0].state, ShardState::Active);
+    }
+
+    #[tokio::test]
+    async fn lookup_shard_routes_correctly() {
+        let (_dir, store) = open_store();
+        let map = ShardMap::load(store).unwrap();
+
+        // Shard 0: ["", "m"), Shard 1: ["m", "")
+        map.put_shard(ShardInfo {
+            shard_id: 0,
+            range: KeyRange {
+                start: String::new(),
+                end: "m".into(),
+            },
+            state: ShardState::Active,
+        })
+        .await
+        .unwrap();
+        map.put_shard(ShardInfo {
+            shard_id: 1,
+            range: KeyRange {
+                start: "m".into(),
+                end: String::new(),
+            },
+            state: ShardState::Active,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(map.lookup_shard("a").await.unwrap().shard_id, 0);
+        assert_eq!(map.lookup_shard("hello").await.unwrap().shard_id, 0);
+        assert_eq!(map.lookup_shard("m").await.unwrap().shard_id, 1);
+        assert_eq!(map.lookup_shard("zebra").await.unwrap().shard_id, 1);
+    }
+
+    #[tokio::test]
+    async fn persistence_survives_reload() {
+        let dir = TempDir::new().unwrap();
+        let store = FjallStore::open(dir.path()).unwrap();
+        let map = ShardMap::load(store).unwrap();
+        map.initialize_default().await.unwrap();
+        drop(map);
+
+        let store2 = FjallStore::open(dir.path()).unwrap();
+        let map2 = ShardMap::load(store2).unwrap();
+        let shards = map2.all_shards().await;
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].shard_id, 0);
+    }
+
+    #[tokio::test]
+    async fn next_shard_id_increments() {
+        let (_dir, store) = open_store();
+        let map = ShardMap::load(store).unwrap();
+        assert_eq!(map.next_shard_id().await, 0);
+        map.initialize_default().await.unwrap();
+        assert_eq!(map.next_shard_id().await, 1);
+    }
+
+    #[test]
+    fn key_range_contains() {
+        let full = KeyRange {
+            start: String::new(),
+            end: String::new(),
+        };
+        assert!(full.contains("anything"));
+
+        let lower = KeyRange {
+            start: String::new(),
+            end: "m".into(),
+        };
+        assert!(lower.contains("a"));
+        assert!(lower.contains(""));
+        assert!(!lower.contains("m"));
+        assert!(!lower.contains("z"));
+
+        let upper = KeyRange {
+            start: "m".into(),
+            end: String::new(),
+        };
+        assert!(!upper.contains("a"));
+        assert!(upper.contains("m"));
+        assert!(upper.contains("z"));
+    }
+}

--- a/crates/ggap-storage/src/types.rs
+++ b/crates/ggap-storage/src/types.rs
@@ -58,7 +58,7 @@ pub struct SnapshotMeta {
 /// round-trip on the node that built it, and remain available on a follower
 /// that receives and installs the snapshot.
 #[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct SnapshotContents {
+pub struct SnapshotContents {
     /// Current value per key (mirrors the `data` partition).
     pub data: Vec<(String, KvEntry)>,
     /// All retained history entries (mirrors the `history` partition),

--- a/crates/ggap-types/src/lib.rs
+++ b/crates/ggap-types/src/lib.rs
@@ -1,5 +1,38 @@
 pub type NodeId = u64;
-pub type ShardId = u64; // always 0 in phases 1-6
+pub type ShardId = u64;
+
+/// Key range owned by a shard: [start, end). Empty end means unbounded.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct KeyRange {
+    /// Inclusive lower bound. Empty string means the minimum possible key.
+    pub start: String,
+    /// Exclusive upper bound. Empty string means unbounded (no upper limit).
+    pub end: String,
+}
+
+impl KeyRange {
+    /// Returns `true` if `key` falls within this range.
+    pub fn contains(&self, key: &str) -> bool {
+        let after_start = self.start.is_empty() || key >= self.start.as_str();
+        let before_end = self.end.is_empty() || key < self.end.as_str();
+        after_start && before_end
+    }
+}
+
+/// State of a shard in the cluster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ShardState {
+    Active,
+    Splitting,
+}
+
+/// Metadata for a single shard.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct ShardInfo {
+    pub shard_id: ShardId,
+    pub range: KeyRange,
+    pub state: ShardState,
+}
 
 /// Stored in last_applied metadata
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -93,4 +126,10 @@ pub enum GgapError {
     Consensus(String),
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
+    #[error("wrong shard for key; try shard {shard_id}")]
+    WrongShard { shard_id: ShardId, range: KeyRange },
+    #[error("shard is splitting, retry later")]
+    ShardSplitting,
+    #[error("shard not found: {0}")]
+    ShardNotFound(ShardId),
 }

--- a/proto/ginnungagap/v1/cluster.proto
+++ b/proto/ginnungagap/v1/cluster.proto
@@ -15,10 +15,13 @@ service AdminService {
   rpc AddLearner       (AddLearnerRequest)        returns (AddLearnerResponse);
   rpc ChangeMembership (ChangeMembershipRequest)  returns (ChangeMembershipResponse);
   rpc TransferLeader   (TransferLeaderRequest)    returns (TransferLeaderResponse);
+  rpc SplitShard       (SplitShardRequest)        returns (SplitShardResponse);
+  rpc ListShards       (ListShardsRequest)        returns (ListShardsResponse);
 }
 
 message RaftMessage {
-  bytes data = 1;
+  uint64 shard_id = 1;
+  bytes data = 2;
 }
 
 message ClusterStatusRequest {}
@@ -55,4 +58,28 @@ message TransferLeaderRequest {
 message TransferLeaderResponse {
   bool ok = 1;
   string error = 2;
+}
+
+message SplitShardRequest {
+  uint64 shard_id = 1;
+  string split_key = 2;
+}
+
+message SplitShardResponse {
+  bool ok = 1;
+  uint64 new_shard_id = 2;
+  string error = 3;
+}
+
+message ListShardsRequest {}
+
+message ShardInfoProto {
+  uint64 shard_id = 1;
+  string range_start = 2;
+  string range_end = 3;
+  string state = 4;
+}
+
+message ListShardsResponse {
+  repeated ShardInfoProto shards = 1;
 }


### PR DESCRIPTION
Implement Phase 7 multi-raft support with a manual admin RPC for
splitting a shard's key range. The split protocol blocks writes on the
source shard during the split to ensure data consistency.

Key changes across all crates:

ggap-types: Add KeyRange, ShardInfo, ShardState types and WrongShard,
ShardSplitting, ShardNotFound error variants.

ggap-storage: Add ShardMap for persistent shard-to-range mapping in
the meta keyspace. Add partial snapshot, install, and delete_range
helpers on FjallStateMachine for the split protocol. Make
SnapshotContents public.

ggap-proto: Add shard_id field to RaftMessage for shard-aware Raft
RPCs. Add SplitShard and ListShards RPCs to AdminService.

ggap-consensus: Add ShardRouter for key-to-shard dispatch. Add
SplitCoordinator implementing the split algorithm (validate, mark
splitting, barrier, snapshot upper half, bootstrap new Raft group,
delete from source, update ShardMap). Make GgapNetworkFactory
shard-aware. Expose raft() on OpenRaftNode.

ggap-server: Refactor KvServiceImpl to route through ShardRouter
instead of a single RaftNode. Refactor RaftServiceImpl to route Raft
RPCs by shard_id. Wire AdminServiceImpl with SplitCoordinator. Map
new error variants to gRPC status codes.

ggap-node: Multi-shard startup loop reading ShardMap and creating one
Raft group per shard. Wire ShardRouter, SplitCoordinator, and TTL GC
per shard.

Includes 5 new integration tests covering split correctness, routing
after split, double splits, scan boundaries, and invalid split
rejection. All 45 tests pass.

https://claude.ai/code/session_01UuX4afgWtgCzXakGgSMwLK