### PR TITLE
refactor: abstract Fjall out of ggap-consensus log storage

### DIFF
--- a/crates/ggap-consensus/src/convert.rs
+++ b/crates/ggap-consensus/src/convert.rs
@@ -56,9 +56,7 @@ pub(crate) fn or_entry_to_log_entry(
 }
 
 /// Convert a domain `LogEntry` back to an openraft `Entry<GgapTypeConfig>`.
-pub(crate) fn log_entry_to_or_entry(
-    entry: &LogEntry,
-) -> Result<Entry<GgapTypeConfig>, GgapError> {
+pub(crate) fn log_entry_to_or_entry(entry: &LogEntry) -> Result<Entry<GgapTypeConfig>, GgapError> {
     let log_id = openraft::log_id::LogId {
         leader_id: LeaderId::new(entry.term, entry.leader_id),
         index: entry.index,

--- a/crates/ggap-consensus/src/convert.rs
+++ b/crates/ggap-consensus/src/convert.rs
@@ -1,5 +1,8 @@
+use ggap_storage::types::{LogEntry, LogPayload, LogState, Vote};
 use ggap_types::GgapError;
-use openraft::LeaderId;
+use openraft::{Entry, EntryPayload, LeaderId, RaftTypeConfig};
+
+use crate::config::GgapTypeConfig;
 
 pub(crate) fn encode<T: serde::Serialize>(v: &T) -> Result<Vec<u8>, GgapError> {
     bincode::serde::encode_to_vec(v, bincode::config::standard())
@@ -11,6 +14,10 @@ pub(crate) fn decode<T: for<'de> serde::Deserialize<'de>>(b: &[u8]) -> Result<T,
         .map(|(v, _)| v)
         .map_err(|e| GgapError::Storage(e.to_string()))
 }
+
+// ---------------------------------------------------------------------------
+// LogId conversions
+// ---------------------------------------------------------------------------
 
 pub(crate) fn or_log_id_to_log_id(log_id: openraft::log_id::LogId<u64>) -> ggap_types::LogId {
     ggap_types::LogId {
@@ -24,5 +31,83 @@ pub(crate) fn log_id_to_or_log_id(log_id: ggap_types::LogId) -> openraft::log_id
     openraft::log_id::LogId {
         leader_id: LeaderId::new(log_id.term, log_id.leader_id),
         index: log_id.index,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry <-> LogEntry conversions
+// ---------------------------------------------------------------------------
+
+/// Convert an openraft `Entry<GgapTypeConfig>` to a domain `LogEntry`.
+pub(crate) fn or_entry_to_log_entry(
+    entry: &<GgapTypeConfig as RaftTypeConfig>::Entry,
+) -> Result<LogEntry, GgapError> {
+    let payload = match &entry.payload {
+        EntryPayload::Blank => LogPayload::Blank,
+        EntryPayload::Normal(cmd) => LogPayload::Normal(cmd.clone()),
+        EntryPayload::Membership(m) => LogPayload::Raw(encode(m)?),
+    };
+    Ok(LogEntry {
+        index: entry.log_id.index,
+        term: entry.log_id.leader_id.term,
+        leader_id: entry.log_id.leader_id.node_id,
+        payload,
+    })
+}
+
+/// Convert a domain `LogEntry` back to an openraft `Entry<GgapTypeConfig>`.
+pub(crate) fn log_entry_to_or_entry(
+    entry: &LogEntry,
+) -> Result<Entry<GgapTypeConfig>, GgapError> {
+    let log_id = openraft::log_id::LogId {
+        leader_id: LeaderId::new(entry.term, entry.leader_id),
+        index: entry.index,
+    };
+    let payload = match &entry.payload {
+        LogPayload::Blank => EntryPayload::Blank,
+        LogPayload::Normal(cmd) => EntryPayload::Normal(cmd.clone()),
+        LogPayload::Raw(bytes) => {
+            let membership = decode(bytes)?;
+            EntryPayload::Membership(membership)
+        }
+    };
+    Ok(Entry { log_id, payload })
+}
+
+// ---------------------------------------------------------------------------
+// Vote conversions
+// ---------------------------------------------------------------------------
+
+/// Convert an openraft `Vote<u64>` to a domain `Vote`.
+pub(crate) fn or_vote_to_vote(vote: &openraft::Vote<u64>) -> Vote {
+    Vote {
+        term: vote.leader_id().term,
+        voted_for: Some(vote.leader_id().node_id),
+        committed: vote.is_committed(),
+    }
+}
+
+/// Convert a domain `Vote` to an openraft `Vote<u64>`.
+pub(crate) fn vote_to_or_vote(vote: &Vote) -> openraft::Vote<u64> {
+    let node_id = vote.voted_for.unwrap_or(0);
+    let leader_id = LeaderId::new(vote.term, node_id);
+    if vote.committed {
+        openraft::Vote::new_committed(leader_id.term, leader_id.node_id)
+    } else {
+        openraft::Vote::new(leader_id.term, leader_id.node_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LogState conversion
+// ---------------------------------------------------------------------------
+
+/// Convert a domain `LogState` to an openraft `LogState`.
+pub(crate) fn log_state_to_or_log_state(
+    state: &LogState,
+) -> openraft::storage::LogState<GgapTypeConfig> {
+    openraft::storage::LogState {
+        last_purged_log_id: state.last_purged_log_id.map(log_id_to_or_log_id),
+        last_log_id: state.last_log_id.map(log_id_to_or_log_id),
     }
 }

--- a/crates/ggap-consensus/src/log_store.rs
+++ b/crates/ggap-consensus/src/log_store.rs
@@ -1,10 +1,8 @@
 use std::fmt::Debug;
 use std::io;
 use std::ops::RangeBounds;
-use std::sync::Arc;
 
-use ggap_storage::fjall::FjallStore;
-use ggap_storage::keys::{meta_key, raft_log_key};
+use ggap_storage::traits::LogStorage;
 use ggap_types::ShardId;
 use openraft::storage::RaftLogStorage;
 use openraft::AnyError;
@@ -14,7 +12,7 @@ use openraft::{
 };
 
 use crate::config::GgapTypeConfig;
-use crate::convert::{decode, encode};
+use crate::convert;
 
 fn sto_err(msg: impl Into<String>) -> StorageError<u64> {
     let io = StorageIOError::new(
@@ -29,23 +27,23 @@ fn sto_err(msg: impl Into<String>) -> StorageError<u64> {
 // GgapLogStorage
 // ---------------------------------------------------------------------------
 
-/// openraft `RaftLogStorage` adapter backed by `FjallStore`.
+/// openraft `RaftLogStorage` adapter backed by any `LogStorage` implementation.
 ///
-/// Stores serialized `Entry<GgapTypeConfig>` in the `raft_log` partition,
-/// keyed by `raft_log_key(shard_id, index)`. Vote and metadata are stored
-/// in the `meta` partition.
-pub struct GgapLogStorage {
-    pub(crate) store: Arc<FjallStore>,
+/// Converts between openraft types and domain types. All storage I/O is
+/// delegated to the underlying `S: LogStorage`; this adapter contains no
+/// fjall-specific code.
+pub struct GgapLogStorage<S: LogStorage> {
+    pub(crate) store: S,
     pub(crate) shard_id: ShardId,
 }
 
-impl GgapLogStorage {
-    pub fn new(store: Arc<FjallStore>, shard_id: ShardId) -> Self {
+impl<S: LogStorage> GgapLogStorage<S> {
+    pub fn new(store: S, shard_id: ShardId) -> Self {
         GgapLogStorage { store, shard_id }
     }
 }
 
-impl Clone for GgapLogStorage {
+impl<S: LogStorage + Clone> Clone for GgapLogStorage<S> {
     fn clone(&self) -> Self {
         GgapLogStorage {
             store: self.store.clone(),
@@ -59,12 +57,11 @@ impl Clone for GgapLogStorage {
 // ---------------------------------------------------------------------------
 
 #[allow(clippy::result_large_err)]
-impl RaftLogReader<GgapTypeConfig> for GgapLogStorage {
+impl<S: LogStorage + Clone> RaftLogReader<GgapTypeConfig> for GgapLogStorage<S> {
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
         &mut self,
         range: RB,
     ) -> Result<Vec<<GgapTypeConfig as RaftTypeConfig>::Entry>, StorageError<u64>> {
-        let store = self.store.clone();
         let shard_id = self.shard_id;
 
         // Resolve bounds to concrete u64 values.
@@ -83,24 +80,16 @@ impl RaftLogReader<GgapTypeConfig> for GgapLogStorage {
             return Ok(vec![]);
         }
 
-        tokio::task::spawn_blocking(move || {
-            let key_start = raft_log_key(shard_id, start).to_vec();
-            let key_end = raft_log_key(shard_id, end).to_vec();
-            store
-                .raft_log
-                .range(key_start..=key_end)
-                .map(|g| {
-                    g.into_inner()
-                        .map_err(|e| sto_err(e.to_string()))
-                        .and_then(|(_, v)| {
-                            decode::<<GgapTypeConfig as RaftTypeConfig>::Entry>(&v)
-                                .map_err(|e| sto_err(e.to_string()))
-                        })
-                })
-                .collect()
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?
+        let entries = self
+            .store
+            .get_entries(shard_id, start, end)
+            .await
+            .map_err(|e| sto_err(e.to_string()))?;
+
+        entries
+            .iter()
+            .map(|e| convert::log_entry_to_or_entry(e).map_err(|e| sto_err(e.to_string())))
+            .collect()
     }
 }
 
@@ -109,123 +98,57 @@ impl RaftLogReader<GgapTypeConfig> for GgapLogStorage {
 // ---------------------------------------------------------------------------
 
 #[allow(clippy::result_large_err)]
-impl RaftLogStorage<GgapTypeConfig> for GgapLogStorage {
-    type LogReader = GgapLogStorage;
+impl<S: LogStorage + Clone> RaftLogStorage<GgapTypeConfig> for GgapLogStorage<S> {
+    type LogReader = GgapLogStorage<S>;
 
     async fn get_log_reader(&mut self) -> Self::LogReader {
         self.clone()
     }
 
     async fn save_vote(&mut self, vote: &Vote<u64>) -> Result<(), StorageError<u64>> {
-        let store = self.store.clone();
-        let shard_id = self.shard_id;
-        let bytes = encode(vote).map_err(|e| sto_err(e.to_string()))?;
-        tokio::task::spawn_blocking(move || {
-            store
-                .meta
-                .insert(meta_key(shard_id, "or_vote"), bytes)
-                .map_err(|e| sto_err(e.to_string()))
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?
+        let domain_vote = convert::or_vote_to_vote(vote);
+        self.store
+            .save_vote(self.shard_id, domain_vote)
+            .await
+            .map_err(|e| sto_err(e.to_string()))
     }
 
     async fn read_vote(&mut self) -> Result<Option<Vote<u64>>, StorageError<u64>> {
-        let store = self.store.clone();
-        let shard_id = self.shard_id;
-        tokio::task::spawn_blocking(move || {
-            match store
-                .meta
-                .get(meta_key(shard_id, "or_vote"))
-                .map_err(|e| sto_err(e.to_string()))?
-            {
-                None => Ok(None),
-                Some(b) => decode::<Vote<u64>>(&b)
-                    .map(Some)
-                    .map_err(|e| sto_err(e.to_string())),
-            }
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?
+        let vote = self
+            .store
+            .read_vote(self.shard_id)
+            .await
+            .map_err(|e| sto_err(e.to_string()))?;
+        Ok(vote.map(|v| convert::vote_to_or_vote(&v)))
     }
 
     async fn get_log_state(&mut self) -> Result<LogState<GgapTypeConfig>, StorageError<u64>> {
-        let store = self.store.clone();
-        let shard_id = self.shard_id;
-        tokio::task::spawn_blocking(move || {
-            // Read last_purged_log_id from meta.
-            let last_purged_log_id: Option<LogId<u64>> = match store
-                .meta
-                .get(meta_key(shard_id, "or_last_purged"))
-                .map_err(|e| sto_err(e.to_string()))?
-            {
-                None => None,
-                Some(b) => Some(decode::<LogId<u64>>(&b).map_err(|e| sto_err(e.to_string()))?),
-            };
-
-            // Read only the last log entry (iterator is DoubleEndedIterator).
-            let start_key = raft_log_key(shard_id, 0).to_vec();
-            let end_key = raft_log_key(shard_id, u64::MAX).to_vec();
-
-            let last_log_id = store
-                .raft_log
-                .range(start_key..=end_key)
-                .next_back()
-                .map(|g| {
-                    g.into_inner()
-                        .map_err(|e| sto_err(e.to_string()))
-                        .and_then(|(_, v)| {
-                            decode::<<GgapTypeConfig as RaftTypeConfig>::Entry>(&v)
-                                .map_err(|e| sto_err(e.to_string()))
-                                .map(|entry| entry.log_id)
-                        })
-                })
-                .transpose()?;
-
-            // If the log is empty, last_log_id falls back to last_purged_log_id.
-            let last_log_id = last_log_id.or(last_purged_log_id);
-
-            Ok(LogState {
-                last_purged_log_id,
-                last_log_id,
-            })
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?
+        let state = self
+            .store
+            .log_state(self.shard_id)
+            .await
+            .map_err(|e| sto_err(e.to_string()))?;
+        Ok(convert::log_state_to_or_log_state(&state))
     }
 
     async fn save_committed(
         &mut self,
         committed: Option<LogId<u64>>,
     ) -> Result<(), StorageError<u64>> {
-        let store = self.store.clone();
-        let shard_id = self.shard_id;
-        let bytes = encode(&committed).map_err(|e| sto_err(e.to_string()))?;
-        tokio::task::spawn_blocking(move || {
-            store
-                .meta
-                .insert(meta_key(shard_id, "or_committed"), bytes)
-                .map_err(|e| sto_err(e.to_string()))
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?
+        let domain_committed = committed.map(convert::or_log_id_to_log_id);
+        self.store
+            .save_committed(self.shard_id, domain_committed)
+            .await
+            .map_err(|e| sto_err(e.to_string()))
     }
 
     async fn read_committed(&mut self) -> Result<Option<LogId<u64>>, StorageError<u64>> {
-        let store = self.store.clone();
-        let shard_id = self.shard_id;
-        tokio::task::spawn_blocking(move || {
-            match store
-                .meta
-                .get(meta_key(shard_id, "or_committed"))
-                .map_err(|e| sto_err(e.to_string()))?
-            {
-                None => Ok(None),
-                Some(b) => decode::<Option<LogId<u64>>>(&b).map_err(|e| sto_err(e.to_string())),
-            }
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?
+        let committed = self
+            .store
+            .read_committed(self.shard_id)
+            .await
+            .map_err(|e| sto_err(e.to_string()))?;
+        Ok(committed.map(convert::log_id_to_or_log_id))
     }
 
     async fn append<I>(
@@ -237,89 +160,36 @@ impl RaftLogStorage<GgapTypeConfig> for GgapLogStorage {
         I: IntoIterator<Item = <GgapTypeConfig as RaftTypeConfig>::Entry> + OptionalSend,
         I::IntoIter: OptionalSend,
     {
-        let store = self.store.clone();
-        let shard_id = self.shard_id;
-        let entries: Vec<_> = entries.into_iter().collect();
+        let domain_entries: Vec<_> = entries
+            .into_iter()
+            .map(|e| convert::or_entry_to_log_entry(&e))
+            .collect::<Result<_, _>>()
+            .map_err(|e| sto_err(e.to_string()))?;
 
-        let result: Result<(), StorageError<u64>> = tokio::task::spawn_blocking(move || {
-            let mut batch = store.db.batch();
-            for entry in &entries {
-                let index = entry.log_id.index;
-                let key = raft_log_key(shard_id, index).to_vec();
-                let val = encode(entry).map_err(|e| sto_err(e.to_string()))?;
-                batch.insert(&store.raft_log, key, val);
-            }
-            batch.commit().map_err(|e| sto_err(e.to_string()))
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?;
+        let result = self
+            .store
+            .append(self.shard_id, domain_entries)
+            .await
+            .map_err(|e| sto_err(e.to_string()));
 
-        // Report flush completion after disk write.
+        // Report flush completion after storage write.
         callback.log_io_completed(result.map_err(|e| io::Error::other(e.to_string())));
         Ok(())
     }
 
     async fn truncate(&mut self, log_id: LogId<u64>) -> Result<(), StorageError<u64>> {
-        let store = self.store.clone();
-        let shard_id = self.shard_id;
-        tokio::task::spawn_blocking(move || {
-            let start = raft_log_key(shard_id, log_id.index).to_vec();
-            let end = raft_log_key(shard_id, u64::MAX).to_vec();
-
-            let keys: Vec<Vec<u8>> = store
-                .raft_log
-                .range(start..=end)
-                .map(|g| {
-                    g.into_inner()
-                        .map(|(k, _)| k.to_vec())
-                        .map_err(|e| sto_err(e.to_string()))
-                })
-                .collect::<Result<_, _>>()?;
-
-            if !keys.is_empty() {
-                let mut batch = store.db.batch();
-                for k in keys {
-                    batch.remove(&store.raft_log, k);
-                }
-                batch.commit().map_err(|e| sto_err(e.to_string()))?;
-            }
-            Ok(())
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?
+        self.store
+            .truncate(self.shard_id, log_id.index)
+            .await
+            .map_err(|e| sto_err(e.to_string()))
     }
 
     async fn purge(&mut self, log_id: LogId<u64>) -> Result<(), StorageError<u64>> {
-        let store = self.store.clone();
-        let shard_id = self.shard_id;
-        tokio::task::spawn_blocking(move || {
-            let start = raft_log_key(shard_id, 0).to_vec();
-            let end = raft_log_key(shard_id, log_id.index).to_vec();
-
-            let keys: Vec<Vec<u8>> = store
-                .raft_log
-                .range(start..=end)
-                .map(|g| {
-                    g.into_inner()
-                        .map(|(k, _)| k.to_vec())
-                        .map_err(|e| sto_err(e.to_string()))
-                })
-                .collect::<Result<_, _>>()?;
-
-            let purged_bytes = encode(&log_id).map_err(|e| sto_err(e.to_string()))?;
-            let mut batch = store.db.batch();
-            for k in keys {
-                batch.remove(&store.raft_log, k);
-            }
-            batch.insert(
-                &store.meta,
-                meta_key(shard_id, "or_last_purged"),
-                purged_bytes,
-            );
-            batch.commit().map_err(|e| sto_err(e.to_string()))
-        })
-        .await
-        .map_err(|e| sto_err(e.to_string()))?
+        let domain_log_id = convert::or_log_id_to_log_id(log_id);
+        self.store
+            .purge(self.shard_id, domain_log_id)
+            .await
+            .map_err(|e| sto_err(e.to_string()))
     }
 }
 

--- a/crates/ggap-consensus/src/split.rs
+++ b/crates/ggap-consensus/src/split.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use openraft::{BasicNode, ServerState};
 
-use ggap_storage::fjall::{FjallStateMachine, FjallStore};
+use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
 use ggap_storage::ShardMap;
 use ggap_types::{GgapError, KeyRange, ShardId, ShardInfo, ShardState};
 
@@ -189,7 +189,7 @@ impl SplitCoordinator {
         self.shard_map.put_shard(new_shard).await?;
 
         // 9. Bootstrap new Raft group for the new shard
-        let log_store = GgapLogStorage::new(self.store.clone(), new_shard_id);
+        let log_store = GgapLogStorage::new(FjallLogStorage(self.store.clone()), new_shard_id);
         let sm = GgapStateMachine::new(self.fsm.clone(), new_shard_id);
         let net = GgapNetworkFactory::new(new_shard_id);
         let cfg = build_raft_config(

--- a/crates/ggap-consensus/tests/sim_cluster.rs
+++ b/crates/ggap-consensus/tests/sim_cluster.rs
@@ -25,7 +25,7 @@ use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapRaft, GgapStateMachine, GgapTypeConfig,
 };
 use ggap_storage::{
-    fjall::{FjallStateMachine, FjallStore},
+    fjall::{FjallLogStorage, FjallStateMachine, FjallStore},
     traits::StateMachineStore,
 };
 use ggap_types::KvCommand;
@@ -235,7 +235,7 @@ impl SimCluster {
             let dir = tempfile::tempdir().unwrap();
             let store = FjallStore::open(dir.path()).unwrap();
             let fsm = Arc::new(FjallStateMachine::new(store.clone()));
-            let log_store = GgapLogStorage::new(store.clone(), 0);
+            let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
             let sm = GgapStateMachine::new(fsm.clone(), 0);
             let net = SimNetworkFactory {
                 from_id: id,
@@ -591,7 +591,7 @@ async fn test_snapshot_catchup() {
     let dir4 = tempfile::tempdir().unwrap();
     let store4 = FjallStore::open(dir4.path()).unwrap();
     let fsm4 = Arc::new(FjallStateMachine::new(store4.clone()));
-    let log_store4 = GgapLogStorage::new(store4.clone(), 0);
+    let log_store4 = GgapLogStorage::new(FjallLogStorage(store4.clone()), 0);
     let sm4 = GgapStateMachine::new(fsm4.clone(), 0);
     let net4 = SimNetworkFactory {
         from_id: new_id,

--- a/crates/ggap-consensus/tests/single_node.rs
+++ b/crates/ggap-consensus/tests/single_node.rs
@@ -6,7 +6,7 @@ use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
 };
 use ggap_storage::{
-    fjall::{FjallStateMachine, FjallStore},
+    fjall::{FjallLogStorage, FjallStateMachine, FjallStore},
     traits::StateMachineStore,
 };
 use ggap_types::{KvCommand, KvResponse};
@@ -17,7 +17,7 @@ async fn single_node_leader_write_read() {
     let dir = tempfile::tempdir().unwrap();
     let store = FjallStore::open(dir.path()).unwrap();
     let fsm = Arc::new(FjallStateMachine::new(store.clone()));
-    let log_store = GgapLogStorage::new(store.clone(), 0);
+    let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
     let sm = GgapStateMachine::new(fsm.clone(), 0);
     let net = GgapNetworkFactory::new(0);
     let cfg = build_raft_config(50, 150, 300, 500);

--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -18,7 +18,7 @@ use ggap_server::{serve_client, serve_cluster, KvServiceConfig};
 use tokio_util::sync::CancellationToken;
 
 use ggap_storage::{
-    fjall::{FjallStateMachine, FjallStore},
+    fjall::{FjallLogStorage, FjallStateMachine, FjallStore},
     ttl::TtlGcTask,
     ShardMap,
 };
@@ -187,7 +187,7 @@ async fn main() -> anyhow::Result<()> {
 
     for shard_info in &shards {
         let shard_id = shard_info.shard_id;
-        let log_store = GgapLogStorage::new(store.clone(), shard_id);
+        let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), shard_id);
         let sm = GgapStateMachine::new(fsm.clone(), shard_id);
         let net = GgapNetworkFactory::new(shard_id);
 

--- a/crates/ggap-server/benches/kv_write.rs
+++ b/crates/ggap-server/benches/kv_write.rs
@@ -25,7 +25,7 @@ use ggap_consensus::{
 };
 use ggap_proto::v1::{kv_service_client::KvServiceClient, PutRequest};
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener, KvServiceConfig};
-use ggap_storage::fjall::{FjallStateMachine, FjallStore};
+use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
 use ggap_storage::ShardMap;
 
 // ---------------------------------------------------------------------------
@@ -57,7 +57,7 @@ async fn start_node(id: u64) -> BenchNode {
     let tempdir = TempDir::new().unwrap();
     let store = FjallStore::open(tempdir.path()).unwrap();
     let fsm = Arc::new(FjallStateMachine::new(store.clone()));
-    let log_store = GgapLogStorage::new(store.clone(), 0);
+    let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
     let sm = GgapStateMachine::new(fsm.clone(), 0);
     let cfg = build_raft_config(HEARTBEAT_MS, ELECTION_MIN_MS, ELECTION_MAX_MS, 50_000);
     let raft = Arc::new(

--- a/crates/ggap-server/tests/split_single_node.rs
+++ b/crates/ggap-server/tests/split_single_node.rs
@@ -17,7 +17,7 @@ use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
     OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
-use ggap_storage::fjall::{FjallStateMachine, FjallStore};
+use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
 use ggap_storage::traits::StateMachineStore;
 use ggap_storage::ShardMap;
 use ggap_types::{KvCommand, KvResponse, ReadMode, WriteMode};
@@ -36,7 +36,7 @@ async fn setup() -> TestSetup {
     let tempdir = TempDir::new().unwrap();
     let store = FjallStore::open(tempdir.path()).unwrap();
     let fsm = Arc::new(FjallStateMachine::new(store.clone()));
-    let log_store = GgapLogStorage::new(store.clone(), 0);
+    let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
     let sm = GgapStateMachine::new(fsm.clone(), 0);
     let cfg = build_raft_config(50, 150, 300, 500);
     let raft = Arc::new(

--- a/crates/ggap-server/tests/three_node_cluster.rs
+++ b/crates/ggap-server/tests/three_node_cluster.rs
@@ -22,7 +22,7 @@ use ggap_consensus::{
     OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener, KvServiceConfig};
-use ggap_storage::fjall::{FjallStateMachine, FjallStore};
+use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
 use ggap_storage::traits::StateMachineStore;
 use ggap_storage::ShardMap;
 use ggap_types::{KvCommand, KvResponse, ReadMode};
@@ -47,7 +47,7 @@ async fn start_node(id: u64) -> TestNode {
     let tempdir = TempDir::new().unwrap();
     let store = FjallStore::open(tempdir.path()).unwrap();
     let fsm = Arc::new(FjallStateMachine::new(store.clone()));
-    let log_store = GgapLogStorage::new(store.clone(), 0);
+    let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
     let sm = GgapStateMachine::new(fsm.clone(), 0);
     // Fast timeouts so tests finish quickly.
     let cfg = build_raft_config(50, 150, 300, 500);

--- a/crates/ggap-storage/src/fjall.rs
+++ b/crates/ggap-storage/src/fjall.rs
@@ -117,16 +117,14 @@ impl LogStorage for FjallLogStorage {
                 .range(start_key..=end_key)
                 .next_back()
                 .map(|g| {
-                    g.into_inner()
-                        .map_err(fjall_err)
-                        .and_then(|(_, v)| {
-                            let entry = decode::<LogEntry>(&v)?;
-                            Ok(LogId {
-                                term: entry.term,
-                                leader_id: entry.leader_id,
-                                index: entry.index,
-                            })
+                    g.into_inner().map_err(fjall_err).and_then(|(_, v)| {
+                        let entry = decode::<LogEntry>(&v)?;
+                        Ok(LogId {
+                            term: entry.term,
+                            leader_id: entry.leader_id,
+                            index: entry.index,
                         })
+                    })
                 })
                 .transpose()?;
 

--- a/crates/ggap-storage/src/fjall.rs
+++ b/crates/ggap-storage/src/fjall.rs
@@ -91,61 +91,52 @@ impl FjallStore {
 /// `LogStorage` backed by fjall.
 ///
 /// All blocking I/O is wrapped in `tokio::task::spawn_blocking`.
+#[derive(Clone)]
 pub struct FjallLogStorage(pub Arc<FjallStore>);
 
 impl LogStorage for FjallLogStorage {
     async fn log_state(&self, shard_id: ShardId) -> Result<LogState, GgapError> {
         let store = self.0.clone();
         tokio::task::spawn_blocking(move || -> Result<LogState, GgapError> {
-            let start = raft_log_key(shard_id, 0).to_vec();
-            let end = raft_log_key(shard_id, u64::MAX).to_vec();
-
-            let mut first_index: Option<u64> = None;
-            let mut last_index: Option<u64> = None;
-
-            for guard in store.raft_log.range(start..=end) {
-                let (k, _) = guard.into_inner().map_err(fjall_err)?;
-                let idx_bytes: [u8; 8] = k[8..16]
-                    .try_into()
-                    .map_err(|_| GgapError::Storage("short raft_log key".into()))?;
-                let idx = u64::from_be_bytes(idx_bytes);
-                if first_index.is_none() {
-                    first_index = Some(idx);
-                }
-                last_index = Some(idx);
-            }
-
-            let last_purged_index = match store
+            // Read last_purged_log_id from meta.
+            let last_purged_log_id = match store
                 .meta
                 .get(meta_key(shard_id, "last_purged"))
                 .map_err(fjall_err)?
             {
-                Some(b) => Some(decode::<u64>(&b)?),
+                Some(b) => Some(decode::<LogId>(&b)?),
                 None => None,
             };
 
-            Ok(LogState {
-                first_index,
-                last_index,
-                last_purged_index,
-            })
-        })
-        .await
-        .map_err(|e| GgapError::Storage(e.to_string()))?
-    }
+            // Read only the last log entry (iterator is DoubleEndedIterator).
+            let start_key = raft_log_key(shard_id, 0).to_vec();
+            let end_key = raft_log_key(shard_id, u64::MAX).to_vec();
 
-    async fn get_entry(
-        &self,
-        shard_id: ShardId,
-        index: u64,
-    ) -> Result<Option<LogEntry>, GgapError> {
-        let store = self.0.clone();
-        tokio::task::spawn_blocking(move || -> Result<Option<LogEntry>, GgapError> {
-            let key = raft_log_key(shard_id, index);
-            match store.raft_log.get(key).map_err(fjall_err)? {
-                Some(b) => Ok(Some(decode::<LogEntry>(&b)?)),
-                None => Ok(None),
-            }
+            let last_log_id = store
+                .raft_log
+                .range(start_key..=end_key)
+                .next_back()
+                .map(|g| {
+                    g.into_inner()
+                        .map_err(fjall_err)
+                        .and_then(|(_, v)| {
+                            let entry = decode::<LogEntry>(&v)?;
+                            Ok(LogId {
+                                term: entry.term,
+                                leader_id: entry.leader_id,
+                                index: entry.index,
+                            })
+                        })
+                })
+                .transpose()?;
+
+            // If the log is empty, last_log_id falls back to last_purged_log_id.
+            let last_log_id = last_log_id.or(last_purged_log_id);
+
+            Ok(LogState {
+                last_log_id,
+                last_purged_log_id,
+            })
         })
         .await
         .map_err(|e| GgapError::Storage(e.to_string()))?
@@ -214,11 +205,11 @@ impl LogStorage for FjallLogStorage {
         .map_err(|e| GgapError::Storage(e.to_string()))?
     }
 
-    async fn purge(&self, shard_id: ShardId, up_to_index: u64) -> Result<(), GgapError> {
+    async fn purge(&self, shard_id: ShardId, up_to: LogId) -> Result<(), GgapError> {
         let store = self.0.clone();
         tokio::task::spawn_blocking(move || -> Result<(), GgapError> {
             let start = raft_log_key(shard_id, 0).to_vec();
-            let end = raft_log_key(shard_id, up_to_index).to_vec();
+            let end = raft_log_key(shard_id, up_to.index).to_vec();
 
             let keys: Vec<Vec<u8>> = store
                 .raft_log
@@ -233,7 +224,7 @@ impl LogStorage for FjallLogStorage {
             batch.insert(
                 &store.meta,
                 meta_key(shard_id, "last_purged"),
-                encode(&up_to_index)?,
+                encode(&up_to)?,
             );
             batch.commit().map_err(fjall_err)
         })
@@ -262,6 +253,38 @@ impl LogStorage for FjallLogStorage {
                 .map_err(fjall_err)?
             {
                 Some(b) => Ok(Some(decode::<Vote>(&b)?)),
+                None => Ok(None),
+            }
+        })
+        .await
+        .map_err(|e| GgapError::Storage(e.to_string()))?
+    }
+
+    async fn save_committed(
+        &self,
+        shard_id: ShardId,
+        committed: Option<LogId>,
+    ) -> Result<(), GgapError> {
+        let store = self.0.clone();
+        tokio::task::spawn_blocking(move || -> Result<(), GgapError> {
+            store
+                .meta
+                .insert(meta_key(shard_id, "committed"), encode(&committed)?)
+                .map_err(fjall_err)
+        })
+        .await
+        .map_err(|e| GgapError::Storage(e.to_string()))?
+    }
+
+    async fn read_committed(&self, shard_id: ShardId) -> Result<Option<LogId>, GgapError> {
+        let store = self.0.clone();
+        tokio::task::spawn_blocking(move || -> Result<Option<LogId>, GgapError> {
+            match store
+                .meta
+                .get(meta_key(shard_id, "committed"))
+                .map_err(fjall_err)?
+            {
+                Some(b) => decode::<Option<LogId>>(&b),
                 None => Ok(None),
             }
         })
@@ -1041,6 +1064,7 @@ mod tests {
         LogEntry {
             index,
             term,
+            leader_id: 1,
             payload: LogPayload::Blank,
         }
     }
@@ -1060,7 +1084,7 @@ mod tests {
         let shard = 0u64;
 
         let state = log.log_state(shard).await.unwrap();
-        assert!(state.first_index.is_none());
+        assert!(state.last_log_id.is_none());
 
         log.append(
             shard,
@@ -1070,23 +1094,26 @@ mod tests {
         .unwrap();
 
         let state = log.log_state(shard).await.unwrap();
-        assert_eq!(state.first_index, Some(1));
-        assert_eq!(state.last_index, Some(3));
-
-        let e = log.get_entry(shard, 2).await.unwrap().unwrap();
-        assert_eq!(e.index, 2);
+        assert_eq!(state.last_log_id.unwrap().index, 3);
 
         let es = log.get_entries(shard, 1, 2).await.unwrap();
         assert_eq!(es.len(), 2);
 
         log.truncate(shard, 3).await.unwrap();
         let state = log.log_state(shard).await.unwrap();
-        assert_eq!(state.last_index, Some(2));
+        assert_eq!(state.last_log_id.unwrap().index, 2);
 
-        log.purge(shard, 1).await.unwrap();
+        let purge_id = LogId {
+            term: 1,
+            leader_id: 1,
+            index: 1,
+        };
+        log.purge(shard, purge_id).await.unwrap();
         let state = log.log_state(shard).await.unwrap();
-        assert_eq!(state.last_purged_index, Some(1));
-        assert!(log.get_entry(shard, 1).await.unwrap().is_none());
+        assert_eq!(state.last_purged_log_id.unwrap().index, 1);
+        // Entry 1 should be gone
+        let es = log.get_entries(shard, 1, 1).await.unwrap();
+        assert!(es.is_empty());
     }
 
     #[tokio::test]

--- a/crates/ggap-storage/src/mem.rs
+++ b/crates/ggap-storage/src/mem.rs
@@ -29,7 +29,7 @@ fn decode<T: for<'de> serde::Deserialize<'de>>(bytes: &[u8]) -> Result<T, GgapEr
 struct MemLogInner {
     entries: BTreeMap<u64, LogEntry>, // index → entry (single shard, Phase 3)
     last_purged: Option<LogId>,
-    votes: HashMap<u64, Vote>,          // shard_id → vote
+    votes: HashMap<u64, Vote>,              // shard_id → vote
     committed: HashMap<u64, Option<LogId>>, // shard_id → committed log id
 }
 

--- a/crates/ggap-storage/src/mem.rs
+++ b/crates/ggap-storage/src/mem.rs
@@ -28,13 +28,15 @@ fn decode<T: for<'de> serde::Deserialize<'de>>(bytes: &[u8]) -> Result<T, GgapEr
 
 struct MemLogInner {
     entries: BTreeMap<u64, LogEntry>, // index → entry (single shard, Phase 3)
-    last_purged: Option<u64>,
-    votes: HashMap<u64, Vote>, // shard_id → vote
+    last_purged: Option<LogId>,
+    votes: HashMap<u64, Vote>,          // shard_id → vote
+    committed: HashMap<u64, Option<LogId>>, // shard_id → committed log id
 }
 
 /// In-memory `LogStorage` backed by a `BTreeMap`.
 ///
 /// Intended for unit tests; not persisted across restarts.
+#[derive(Clone)]
 pub struct MemLogStorage {
     inner: Arc<RwLock<MemLogInner>>,
 }
@@ -46,6 +48,7 @@ impl MemLogStorage {
                 entries: BTreeMap::new(),
                 last_purged: None,
                 votes: HashMap::new(),
+                committed: HashMap::new(),
             })),
         }
     }
@@ -60,19 +63,20 @@ impl Default for MemLogStorage {
 impl LogStorage for MemLogStorage {
     async fn log_state(&self, _shard_id: ShardId) -> Result<LogState, GgapError> {
         let g = self.inner.read().await;
+        let last_log_id = g
+            .entries
+            .values()
+            .next_back()
+            .map(|e| LogId {
+                term: e.term,
+                leader_id: e.leader_id,
+                index: e.index,
+            })
+            .or(g.last_purged);
         Ok(LogState {
-            first_index: g.entries.keys().next().copied(),
-            last_index: g.entries.keys().next_back().copied(),
-            last_purged_index: g.last_purged,
+            last_log_id,
+            last_purged_log_id: g.last_purged,
         })
-    }
-
-    async fn get_entry(
-        &self,
-        _shard_id: ShardId,
-        index: u64,
-    ) -> Result<Option<LogEntry>, GgapError> {
-        Ok(self.inner.read().await.entries.get(&index).cloned())
     }
 
     async fn get_entries(
@@ -102,10 +106,10 @@ impl LogStorage for MemLogStorage {
         Ok(())
     }
 
-    async fn purge(&self, _shard_id: ShardId, up_to_index: u64) -> Result<(), GgapError> {
+    async fn purge(&self, _shard_id: ShardId, up_to: LogId) -> Result<(), GgapError> {
         let mut g = self.inner.write().await;
-        g.entries.retain(|&idx, _| idx > up_to_index);
-        g.last_purged = Some(up_to_index);
+        g.entries.retain(|&idx, _| idx > up_to.index);
+        g.last_purged = Some(up_to);
         Ok(())
     }
 
@@ -116,6 +120,30 @@ impl LogStorage for MemLogStorage {
 
     async fn read_vote(&self, shard_id: ShardId) -> Result<Option<Vote>, GgapError> {
         Ok(self.inner.read().await.votes.get(&shard_id).cloned())
+    }
+
+    async fn save_committed(
+        &self,
+        shard_id: ShardId,
+        committed: Option<LogId>,
+    ) -> Result<(), GgapError> {
+        self.inner
+            .write()
+            .await
+            .committed
+            .insert(shard_id, committed);
+        Ok(())
+    }
+
+    async fn read_committed(&self, shard_id: ShardId) -> Result<Option<LogId>, GgapError> {
+        Ok(self
+            .inner
+            .read()
+            .await
+            .committed
+            .get(&shard_id)
+            .cloned()
+            .flatten())
     }
 }
 
@@ -396,6 +424,7 @@ mod tests {
         LogEntry {
             index,
             term,
+            leader_id: 1,
             payload: LogPayload::Blank,
         }
     }
@@ -407,9 +436,8 @@ mod tests {
 
         // Empty state
         let state = store.log_state(shard).await.unwrap();
-        assert!(state.first_index.is_none());
-        assert!(state.last_index.is_none());
-        assert!(state.last_purged_index.is_none());
+        assert!(state.last_log_id.is_none());
+        assert!(state.last_purged_log_id.is_none());
 
         // Append entries 1..=3
         store
@@ -421,12 +449,7 @@ mod tests {
             .unwrap();
 
         let state = store.log_state(shard).await.unwrap();
-        assert_eq!(state.first_index, Some(1));
-        assert_eq!(state.last_index, Some(3));
-
-        // Get individual entry
-        let e = store.get_entry(shard, 2).await.unwrap().unwrap();
-        assert_eq!(e.index, 2);
+        assert_eq!(state.last_log_id.unwrap().index, 3);
 
         // Get range
         let entries = store.get_entries(shard, 1, 2).await.unwrap();
@@ -435,13 +458,17 @@ mod tests {
         // Truncate from index 3 (removes index 3)
         store.truncate(shard, 3).await.unwrap();
         let state = store.log_state(shard).await.unwrap();
-        assert_eq!(state.last_index, Some(2));
+        assert_eq!(state.last_log_id.unwrap().index, 2);
 
         // Purge up to index 1
-        store.purge(shard, 1).await.unwrap();
+        let purge_id = LogId {
+            term: 1,
+            leader_id: 1,
+            index: 1,
+        };
+        store.purge(shard, purge_id).await.unwrap();
         let state = store.log_state(shard).await.unwrap();
-        assert_eq!(state.first_index, Some(2));
-        assert_eq!(state.last_purged_index, Some(1));
+        assert_eq!(state.last_purged_log_id.unwrap().index, 1);
     }
 
     #[tokio::test]

--- a/crates/ggap-storage/src/traits.rs
+++ b/crates/ggap-storage/src/traits.rs
@@ -18,14 +18,6 @@ pub trait LogStorage: Send + Sync + 'static {
         shard_id: ShardId,
     ) -> impl Future<Output = Result<LogState, GgapError>> + Send;
 
-    /// Return the entry at `index`, or `None` if it has been purged or does
-    /// not exist.
-    fn get_entry(
-        &self,
-        shard_id: ShardId,
-        index: u64,
-    ) -> impl Future<Output = Result<Option<LogEntry>, GgapError>> + Send;
-
     /// Return all entries in the inclusive range `[from, to_inclusive]`.
     fn get_entries(
         &self,
@@ -49,12 +41,12 @@ pub trait LogStorage: Send + Sync + 'static {
         from_index: u64,
     ) -> impl Future<Output = Result<(), GgapError>> + Send;
 
-    /// Delete all entries with `index <= up_to_index` (post-snapshot GC).
-    /// Updates `last_purged_index`.
+    /// Delete all entries with `index <= up_to.index` (post-snapshot GC).
+    /// Stores the full `LogId` as the purge marker for `log_state()`.
     fn purge(
         &self,
         shard_id: ShardId,
-        up_to_index: u64,
+        up_to: LogId,
     ) -> impl Future<Output = Result<(), GgapError>> + Send;
 
     /// Durably persist the vote for the shard (called before granting a vote).
@@ -69,6 +61,19 @@ pub trait LogStorage: Send + Sync + 'static {
         &self,
         shard_id: ShardId,
     ) -> impl Future<Output = Result<Option<Vote>, GgapError>> + Send;
+
+    /// Durably persist the committed log id for the shard.
+    fn save_committed(
+        &self,
+        shard_id: ShardId,
+        committed: Option<LogId>,
+    ) -> impl Future<Output = Result<(), GgapError>> + Send;
+
+    /// Retrieve the last persisted committed log id for the shard.
+    fn read_committed(
+        &self,
+        shard_id: ShardId,
+    ) -> impl Future<Output = Result<Option<LogId>, GgapError>> + Send;
 }
 
 /// Persistent key-value state machine for a single shard.

--- a/crates/ggap-storage/src/types.rs
+++ b/crates/ggap-storage/src/types.rs
@@ -5,6 +5,7 @@ use ggap_types::{KvCommand, KvEntry, LogId};
 pub struct LogEntry {
     pub index: u64,
     pub term: u64,
+    pub leader_id: u64,
     pub payload: LogPayload,
 }
 
@@ -34,12 +35,10 @@ pub struct Vote {
 /// Summary of the current log extent for a shard.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LogState {
-    /// Smallest index currently in the log (`None` if log is empty).
-    pub first_index: Option<u64>,
-    /// Largest index currently in the log (`None` if log is empty).
-    pub last_index: Option<u64>,
-    /// Largest index that has been purged (compacted into a snapshot).
-    pub last_purged_index: Option<u64>,
+    /// Full `LogId` of the last entry in the log, or `None` if the log is empty.
+    pub last_log_id: Option<LogId>,
+    /// Full `LogId` of the last purged entry (compacted into a snapshot).
+    pub last_purged_log_id: Option<LogId>,
 }
 
 /// Metadata identifying a snapshot.


### PR DESCRIPTION
## Summary

- **Eliminates Fjall leakage from `ggap-consensus/src/log_store.rs`** — `GgapLogStorage` is now generic over `S: LogStorage` with zero fjall imports. All storage I/O delegates through the `LogStorage` trait; type conversion is handled in the `convert` module.
- **Enriches `LogStorage` trait** to cover all openraft adapter needs: adds `save_committed`/`read_committed`, changes `purge` to accept full `LogId`, removes unused `get_entry`.
- **Enriches domain types** — `LogEntry` gains `leader_id: u64`, `LogState` uses `Option<LogId>` instead of bare indices — closing the information gap that forced the original bypass.

### Before
Two parallel fjall implementations existed: `FjallLogStorage` (trait-based, in ggap-storage) and `GgapLogStorage` (bypassing the trait, directly accessing `FjallStore` keyspaces in ggap-consensus). They used incompatible meta keys and entry formats.

### After
`GgapLogStorage<S: LogStorage>` delegates all storage through the trait. `FjallLogStorage` is the single fjall implementation. DST tests can now be switched to `MemLogStorage` if desired.

## Files changed (13)
| Layer | Files | Change |
|---|---|---|
| **ggap-storage** | `types.rs`, `traits.rs`, `fjall.rs`, `mem.rs` | Enriched types + trait, updated both impls |
| **ggap-consensus** | `log_store.rs`, `convert.rs`, `split.rs` | Rewrote adapter as generic, added conversions |
| **Tests/wiring** | `main.rs`, 3 test files, 1 bench | Wire `FjallLogStorage` → `GgapLogStorage` |

## Test plan
- [x] `cargo build --workspace` — zero errors
- [x] `cargo test --workspace` — 56 tests pass
- [x] `cargo clippy --workspace --tests -- -D warnings` — zero warnings
- [x] `grep fjall crates/ggap-consensus/src/log_store.rs` — only appears in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)