### PR TITLE
test: verify snapshot install in snapshot catchup DST test (P0-2)

### DIFF
--- a/crates/ggap-consensus/tests/sim_cluster.rs
+++ b/crates/ggap-consensus/tests/sim_cluster.rs
@@ -807,6 +807,21 @@ async fn test_snapshot_catchup() {
         );
     }
 
+    // Verify that node 4 caught up via snapshot install (not just log replication).
+    // If a snapshot was installed, raft4.metrics().borrow().snapshot should be Some(_).
+    let metrics4 = raft4.metrics().borrow().clone();
+    assert!(
+        metrics4.snapshot.is_some(),
+        "node 4 should have installed a snapshot, but metrics.snapshot is None"
+    );
+
+    // last_applied should be at least the index of the 20th write.
+    let last_applied_index = metrics4.last_applied.map(|lid| lid.index).unwrap_or(0);
+    assert!(
+        last_applied_index >= 20,
+        "node 4 last_applied index {last_applied_index} should be >= 20"
+    );
+
     let _ = raft4.shutdown().await;
     drop(dir4);
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Addresses dst-plan.md P0 item #2: `test_snapshot_catchup` previously only verified that node 4 had all 20 keys, but did not confirm a snapshot was actually installed (log replication alone could have satisfied the assertion).
- Adds `metrics4.snapshot.is_some()` check to assert a snapshot was installed on node 4 after catchup.
- Adds `last_applied index >= 20` check to confirm node 4 applied all expected entries.

## Test plan

- [ ] `cargo test --all` passes with the new assertions in `test_snapshot_catchup`
- [ ] Assertions use the existing `raft4.metrics().borrow()` pattern already present in the file
- [ ] `metrics4.snapshot` maps to `Option<LogId<NID>>` in openraft 0.9 `RaftMetrics` — confirmed via source

https://claude.ai/code/session_01Gte53j17wMoWMnZqBvW5TA
EOF
)