### PR TITLE
Expand README with comprehensive cluster setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,19 @@ All storage keys are prefixed with `be_u64(shard_id)`, so splitting is a metadat
 - **Single-shard scans** — scans that span shard boundaries are rejected; clients must issue per-shard scans
 - **Writes blocked during split** — the source shard is unavailable for writes while the split executes
 
+## Building
+
+```bash
+cargo build --release -p ggap-node
+# binary at: target/release/ggap-node
+```
+
 ## Running
 
 ### Single node
 
 ```bash
-cargo run -p ggap-node -- \
+ggap-node \
   --node-id 1 \
   --client-addr 127.0.0.1:17000 \
   --cluster-addr 127.0.0.1:17001 \
@@ -91,7 +98,7 @@ A production-grade Raft cluster runs 3 or 5 nodes (odd count ensures a majority 
 **Terminal 1 — node 1 (bootstraps as initial leader)**
 
 ```bash
-cargo run -p ggap-node -- \
+ggap-node \
   --node-id 1 \
   --client-addr 127.0.0.1:17000 \
   --cluster-addr 127.0.0.1:17001 \
@@ -103,7 +110,7 @@ Node 1 initialises a single-member Raft group on first boot and immediately beco
 **Terminal 2 — node 2**
 
 ```bash
-cargo run -p ggap-node -- \
+ggap-node \
   --node-id 2 \
   --client-addr 127.0.0.1:17010 \
   --cluster-addr 127.0.0.1:17011 \
@@ -113,7 +120,7 @@ cargo run -p ggap-node -- \
 **Terminal 3 — node 3**
 
 ```bash
-cargo run -p ggap-node -- \
+ggap-node \
   --node-id 3 \
   --client-addr 127.0.0.1:17020 \
   --cluster-addr 127.0.0.1:17021 \

--- a/README.md
+++ b/README.md
@@ -74,12 +74,77 @@ All storage keys are prefixed with `be_u64(shard_id)`, so splitting is a metadat
 
 ## Running
 
+### Single node
+
 ```bash
 cargo run -p ggap-node -- \
   --node-id 1 \
   --client-addr 127.0.0.1:17000 \
-  --cluster-addr 127.0.0.1:17001
+  --cluster-addr 127.0.0.1:17001 \
+  --data-dir /tmp/ggap-node1
 ```
+
+### Multi-node cluster
+
+A production-grade Raft cluster runs 3 or 5 nodes (odd count ensures a majority quorum can always form). Each node requires a unique `--node-id`, `--client-addr` (gRPC for clients), `--cluster-addr` (internal Raft RPC), and `--data-dir`.
+
+**Terminal 1 — node 1 (bootstraps as initial leader)**
+
+```bash
+cargo run -p ggap-node -- \
+  --node-id 1 \
+  --client-addr 127.0.0.1:17000 \
+  --cluster-addr 127.0.0.1:17001 \
+  --data-dir /tmp/ggap-node1
+```
+
+Node 1 initialises a single-member Raft group on first boot and immediately becomes leader.
+
+**Terminal 2 — node 2**
+
+```bash
+cargo run -p ggap-node -- \
+  --node-id 2 \
+  --client-addr 127.0.0.1:17010 \
+  --cluster-addr 127.0.0.1:17011 \
+  --data-dir /tmp/ggap-node2
+```
+
+**Terminal 3 — node 3**
+
+```bash
+cargo run -p ggap-node -- \
+  --node-id 3 \
+  --client-addr 127.0.0.1:17020 \
+  --cluster-addr 127.0.0.1:17021 \
+  --data-dir /tmp/ggap-node3
+```
+
+**Add nodes to the cluster**
+
+Once all three processes are running, register nodes 2 and 3 as learners by calling the leader's cluster port (17001):
+
+```bash
+# Add node 2 as a learner
+grpcurl -plaintext \
+  -d '{"node":{"node_id":2,"client_addr":"127.0.0.1:17010","cluster_addr":"127.0.0.1:17011"}}' \
+  localhost:17001 ginnungagap.v1.AdminService/AddLearner
+
+# Add node 3 as a learner
+grpcurl -plaintext \
+  -d '{"node":{"node_id":3,"client_addr":"127.0.0.1:17020","cluster_addr":"127.0.0.1:17021"}}' \
+  localhost:17001 ginnungagap.v1.AdminService/AddLearner
+```
+
+Then promote all three to voting members:
+
+```bash
+grpcurl -plaintext \
+  -d '{"node_ids":[1,2,3]}' \
+  localhost:17001 ginnungagap.v1.AdminService/ChangeMembership
+```
+
+> **Note:** `AddLearner` and `ChangeMembership` currently return `UNIMPLEMENTED` — the gRPC membership-management handlers are not yet wired up. Once complete, the flow above will be the standard way to grow or shrink the cluster without a restart.
 
 With [grpcurl](https://github.com/fullstorydev/grpcurl) (server reflection is enabled, no `--proto` needed):
 


### PR DESCRIPTION
## Summary
Enhanced the README documentation with detailed instructions for running both single-node and multi-node Raft cluster configurations, including step-by-step setup procedures and gRPC commands for cluster membership management.

## Changes
- Added **Single node** section with basic startup example
- Added **Multi-node cluster** section with:
  - Explanation of production-grade Raft cluster requirements (3 or 5 nodes)
  - Step-by-step terminal instructions for bootstrapping a 3-node cluster
  - Node configuration details (unique node-id, client-addr, cluster-addr, data-dir)
  - gRPC commands using `grpcurl` to add learners and promote to voting members
  - Note about `AddLearner` and `ChangeMembership` being currently unimplemented
- Updated existing code example to include `--data-dir` parameter for consistency

## Notable Details
- Documentation clarifies that node 1 bootstraps as the initial leader on first boot
- Provides concrete port assignments for multi-node setup (17000-17021 range)
- Includes example data directory paths for easy local testing
- Explains the learner → voting member promotion workflow for cluster growth

https://claude.ai/code/session_017w94fZP5VLVHeLZr2Jni5e