### PR TITLE
refactor: abstract Fjall out of ggap-consensus log storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ name = "ggap-node"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "clap",
  "figment",
  "ggap-consensus",

--- a/SPLIT_PLAN.md
+++ b/SPLIT_PLAN.md
@@ -1,0 +1,208 @@
+# Fix Shard Split: Raft-Replicated Data Movement + Full Membership
+
+## Context
+
+`SplitCoordinator::do_split` has two problems:
+1. **Data movement is local-only** — `build_partial_snapshot`, `install_partial_snapshot`, and `delete_range_from` run only on the leader node. Other nodes in the cluster never split their data.
+2. **New shard initialized as single-node** — the new Raft group is created with only the local node, losing replication even though the source shard has 3 (or more) members.
+
+The fix: propose a `Split` command through the source shard's Raft log so every node applies the data split deterministically, then bootstrap the new shard's Raft group with the source shard's membership.
+
+## Design
+
+### New command flow
+
+```
+Coordinator (leader)                    All nodes (via Raft apply)
+─────────────────────                   ─────────────────────────
+1. Validate split request
+2. Mark source shard Splitting
+3. Read source membership
+4. Allocate new_shard_id
+5. Propose KvCommand::Split ──────────► 6. apply(): copy keys >= split_key
+   { split_key, new_shard_id }             to new_shard_id, delete from source
+                                        7. Signal: "new shard ready"
+                                        8. Background task creates Raft
+                                           instance + registers in router
+9. Wait for local Raft instance
+10. Initialize with source membership
+11. Update ShardMap (narrowed source +
+    new shard ranges)
+```
+
+The write barrier is built-in: the Split command is ordered in the log after all prior writes.
+
+### Raft group bootstrap on non-leader nodes
+
+Each node needs a Raft instance for the new shard. Approach: **side-channel from apply**.
+
+`GgapStateMachine` gets an `mpsc::UnboundedSender<SplitApplied>` channel. When it applies a Split command, it sends a `SplitApplied { new_shard_id }` event. A background task on each node receives this and creates the Raft instance + registers it in the router.
+
+On the **leader** specifically, the coordinator waits for the local Raft instance to appear in the router, then calls `raft.initialize(source_membership)`. OpenRaft replicates to followers; if a follower's background task hasn't created its instance yet, the RPC returns "shard not found" and openraft retries automatically.
+
+This is the same pattern CockroachDB and TiKV use for region splits — the split is a Raft command, and each node independently creates the new Raft group infrastructure as part of (or immediately after) applying it.
+
+## Changes by file
+
+### 1. `crates/ggap-types/src/lib.rs`
+
+Add variant to `KvCommand`:
+```rust
+Split {
+    split_key: String,
+    new_shard_id: ShardId,
+    source_range: KeyRange,
+},
+```
+
+Add variant to `KvResponse`:
+```rust
+SplitComplete { new_shard_id: ShardId },
+```
+
+### 2. `crates/ggap-storage/src/fjall.rs` — `FjallStateMachine::apply()`
+
+Add a `KvCommand::Split` arm. The current `apply()` runs entirely inside `spawn_blocking`, and the split helpers (`build_partial_snapshot` etc.) are async wrappers around their own `spawn_blocking`. To avoid nested spawn_blocking, extract the synchronous inner logic from each helper into a `fn(&FjallStore, ...)` and call those directly within the existing `spawn_blocking` block.
+
+```rust
+Some(KvCommand::Split { split_key, new_shard_id, source_range }) => {
+    // Inside the existing spawn_blocking:
+    // 1. Data movement (reuse extracted sync inner fns)
+    let contents = build_partial_snapshot_sync(&store, shard_id, &split_key)?;
+    install_partial_snapshot_sync(&store, new_shard_id, &contents)?;
+    delete_range_from_sync(&store, shard_id, &split_key)?;
+
+    // 2. Update ShardMap: narrow source, add new shard
+    //    (deterministic on all nodes — no external reads)
+    let updated_source = ShardInfo {
+        shard_id,
+        range: KeyRange { start: source_range.start, end: split_key.clone() },
+        state: ShardState::Active,
+    };
+    let new_shard = ShardInfo {
+        shard_id: new_shard_id,
+        range: KeyRange { start: split_key, end: source_range.end },
+        state: ShardState::Active,
+    };
+    // ShardMap needs a sync put method (or batch write to meta keyspace directly)
+
+    // 3. Signal split_tx channel (must be done outside spawn_blocking)
+    return KvResponse::SplitComplete { new_shard_id };
+}
+```
+
+**ShardMap update in apply**: `ShardMap` currently has async methods. For the sync `spawn_blocking` context, either:
+- Add `put_shard_sync(&self, info)` that writes directly to fjall (no async)
+- Or handle the ShardMap update outside `spawn_blocking` after the data movement returns
+
+The split_tx channel send also needs to happen outside `spawn_blocking` (tokio channels aren't usable in blocking context). So the Split arm should likely be handled as a separate code path that runs data movement in `spawn_blocking`, then does ShardMap + channel signaling in async context afterward.
+
+### 3. `crates/ggap-storage/src/fjall.rs` — Split signal channel
+
+Add to `FjallStateMachine`:
+```rust
+split_tx: Option<tokio::sync::mpsc::UnboundedSender<SplitApplied>>,
+```
+
+New struct:
+```rust
+pub struct SplitApplied {
+    pub new_shard_id: ShardId,
+}
+```
+
+Add setter method:
+```rust
+pub fn set_split_sender(&mut self, tx: mpsc::UnboundedSender<SplitApplied>) {
+    self.split_tx = Some(tx);
+}
+```
+
+When the Split command is applied, send the event through the channel.
+
+### 4. `crates/ggap-consensus/src/state_machine.rs` — `GgapStateMachine::apply()`
+
+The `EntryPayload::Normal(cmd)` arm already passes through to `fsm.apply()`. No change needed here — the new `KvCommand::Split` variant flows through naturally.
+
+### 5. `crates/ggap-consensus/src/split.rs` — `SplitCoordinator`
+
+Refactor `do_split()`:
+
+```
+1. Get source node from router
+2. Read source shard info (for range) from shard_map
+3. Read source membership from source_node.raft()
+   (openraft 0.9: raft.with_raft_state(|st| st.membership_state...) or
+    check metrics/get_membership API)
+4. Allocate new_shard_id via shard_map.next_shard_id()
+5. Propose KvCommand::Split { split_key, new_shard_id, source_range }
+   via source_node.raft().client_write(cmd)
+   — This replaces: ensure_linearizable + build_partial_snapshot +
+     install_partial_snapshot + delete_range_from + ShardMap updates
+   — ShardMap is now updated inside apply on all nodes
+6. Wait for new shard's Raft instance to appear in router
+   (poll router.get_node(new_shard_id) with timeout)
+7. Initialize new shard's Raft with source membership:
+   new_raft.initialize(source_members)
+8. Wait for new shard leader election
+```
+
+Remove: all local Raft creation code (lines 192-226) — moves to background split handler.
+Remove: ShardMap updates from coordinator — moves to apply path.
+Remove: `ensure_linearizable()` — the Split command IS the barrier.
+
+### 6. `crates/ggap-consensus/src/node.rs` or new file — Background split handler
+
+New async task that runs on every node:
+```rust
+pub async fn run_split_handler(
+    mut rx: mpsc::UnboundedReceiver<SplitApplied>,
+    store: Arc<FjallStore>,
+    fsm: Arc<FjallStateMachine>,
+    router: Arc<ShardRouter>,
+    node_id: u64,
+    cluster_addr: String,
+    raft_config: Arc<openraft::Config>,
+) {
+    while let Some(event) = rx.recv().await {
+        let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), event.new_shard_id);
+        let sm = GgapStateMachine::new(fsm.clone(), event.new_shard_id);
+        let net = GgapNetworkFactory::new(event.new_shard_id);
+        let raft = Arc::new(GgapRaft::new(node_id, raft_config.clone(), net, log_store, sm).await.unwrap());
+        let node = Arc::new(OpenRaftNode::new(raft.clone(), fsm.clone(), event.new_shard_id, node_id, ...));
+        let cluster = Arc::new(OpenRaftCluster::new(raft));
+        router.add_shard(event.new_shard_id, node, cluster).await;
+    }
+}
+```
+
+Spawned in `ggap-node/src/main.rs` alongside the gRPC servers.
+
+### 7. `crates/ggap-node/src/main.rs`
+
+- Create the `mpsc::unbounded_channel()` for split events
+- Pass the sender to `FjallStateMachine` via `set_split_sender()`
+- Spawn `run_split_handler` task
+- Pass the necessary context (store, fsm, router, node_id, cluster_addr, raft_config)
+
+### 8. `crates/ggap-server/src/kv_service.rs`
+
+The `unreachable!()` guards for unexpected `KvResponse` variants in Put/Delete/CAS handlers don't need changes — `SplitComplete` will only be returned to the coordinator's `client_write` call, not through the KV service path.
+
+However, if a `Split` command somehow arrives through the normal KV propose path, it would return `SplitComplete` which hits `unreachable!()`. This is fine — the split is only proposed by the coordinator.
+
+## Design decisions (confirmed)
+
+- **Raft bootstrap on followers**: Side-channel from apply. `FjallStateMachine` sends `SplitApplied` events through an mpsc channel. Background task on each node creates the Raft instance. Leader calls `initialize()` after its local instance is ready; openraft retries handle any follower lag.
+- **ShardMap sync**: Updated deterministically in apply on all nodes. The `KvCommand::Split` carries `source_range: KeyRange` so each node can compute both new ranges without reading ShardMap (which would be non-deterministic if out of sync).
+
+## Verification
+
+1. **Unit test**: Extend existing `FjallStateMachine` tests to apply a `KvCommand::Split` and verify data is correctly split across shard_ids
+2. **Integration test**: Extend `three_node_cluster.rs`:
+   - Write keys spanning the alphabet
+   - Call `split_shard` via admin gRPC
+   - Verify all keys are still readable (some from source shard, some from new shard)
+   - Verify both shards have 3 members
+   - Kill a node and verify both shards remain available
+3. **DST**: Extend `sim_cluster.rs` with a split-under-load scenario

--- a/crates/ggap-consensus/src/lib.rs
+++ b/crates/ggap-consensus/src/lib.rs
@@ -25,7 +25,7 @@ pub use log_store::GgapLogStorage;
 pub use network::{GgapNetwork, GgapNetworkFactory};
 pub use node::{ClusterNode, GgapRaft, LeaseManager, OpenRaftCluster, OpenRaftNode};
 pub use router::ShardRouter;
-pub use split::{SplitCoordinator, SplitCoordinatorConfig};
+pub use split::{run_split_handler, SplitCoordinator, SplitCoordinatorConfig};
 pub use state_machine::{GgapSnapshotBuilder, GgapStateMachine};
 
 // ---------------------------------------------------------------------------
@@ -136,6 +136,9 @@ impl RaftNode for StubRaftNode {
             KvCommand::Delete { key } => Ok(KvResponse::Deleted {
                 found: g.data.remove(&key).is_some(),
             }),
+            KvCommand::Split { .. } => Err(GgapError::InvalidArgument(
+                "Split command not supported by StubRaftNode".into(),
+            )),
             KvCommand::Cas {
                 key,
                 expected,

--- a/crates/ggap-consensus/src/split.rs
+++ b/crates/ggap-consensus/src/split.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use openraft::{BasicNode, ServerState};
 
 use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
-use ggap_storage::SplitApplied;
 use ggap_storage::ShardMap;
+use ggap_storage::SplitApplied;
 use ggap_types::{GgapError, KvCommand, KvResponse, ShardId, ShardInfo, ShardState};
 
 use crate::log_store::GgapLogStorage;
@@ -146,20 +146,15 @@ impl SplitCoordinator {
                 .map(|(id, node)| (*id, node.addr.clone()))
                 .collect(),
         };
-        let write_result = source_node
-            .raft()
-            .client_write(cmd)
-            .await
-            .map_err(|e| {
-                if let Some(fwd) = e.forward_to_leader() {
-                    let leader_addr =
-                        fwd.leader_node.as_ref().map(|n: &BasicNode| n.addr.clone());
-                    return GgapError::NotLeader {
-                        leader: leader_addr,
-                    };
-                }
-                GgapError::Consensus(format!("Split propose failed: {e}"))
-            })?;
+        let write_result = source_node.raft().client_write(cmd).await.map_err(|e| {
+            if let Some(fwd) = e.forward_to_leader() {
+                let leader_addr = fwd.leader_node.as_ref().map(|n: &BasicNode| n.addr.clone());
+                return GgapError::NotLeader {
+                    leader: leader_addr,
+                };
+            }
+            GgapError::Consensus(format!("Split propose failed: {e}"))
+        })?;
 
         // Validate the response.
         match write_result.data {
@@ -252,7 +247,10 @@ pub async fn run_split_handler(
 ) {
     while let Some(event) = rx.recv().await {
         let new_shard_id = event.new_shard_id;
-        tracing::info!(new_shard_id, "background split handler: bootstrapping new shard");
+        tracing::info!(
+            new_shard_id,
+            "background split handler: bootstrapping new shard"
+        );
 
         let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), new_shard_id);
         let sm = GgapStateMachine::new(fsm.clone(), new_shard_id);

--- a/crates/ggap-consensus/src/split.rs
+++ b/crates/ggap-consensus/src/split.rs
@@ -5,10 +5,10 @@ use std::time::Duration;
 use openraft::{BasicNode, ServerState};
 
 use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
+use ggap_storage::SplitApplied;
 use ggap_storage::ShardMap;
-use ggap_types::{GgapError, KeyRange, ShardId, ShardInfo, ShardState};
+use ggap_types::{GgapError, KvCommand, KvResponse, ShardId, ShardInfo, ShardState};
 
-use crate::config::build_raft_config;
 use crate::log_store::GgapLogStorage;
 use crate::network::GgapNetworkFactory;
 use crate::node::{GgapRaft, OpenRaftCluster, OpenRaftNode};
@@ -19,41 +19,16 @@ use crate::state_machine::GgapStateMachine;
 pub struct SplitCoordinatorConfig {
     pub router: Arc<ShardRouter>,
     pub shard_map: Arc<ShardMap>,
-    pub store: Arc<FjallStore>,
-    pub fsm: Arc<FjallStateMachine>,
-    pub node_id: u64,
-    pub cluster_addr: String,
-    pub heartbeat_ms: u64,
-    pub election_min_ms: u64,
-    pub election_max_ms: u64,
-    pub snapshot_threshold: u64,
 }
 
 /// Coordinates the split of a shard's key range into two shards.
 ///
-/// The split protocol blocks writes on the source shard during the split
-/// to ensure consistency. The steps are:
-///
-/// 1. Validate the split request
-/// 2. Mark source shard as Splitting (blocks writes via router)
-/// 3. Write barrier: propose a no-op and wait for commit
-/// 4. Build partial snapshot of keys >= split_key
-/// 5. Bootstrap new Raft group with new ShardId
-/// 6. Install partial snapshot on new shard
-/// 7. Delete transferred keys from source shard
-/// 8. Update ShardMap with new ranges
-/// 9. Resume writes on source shard (state → Active)
+/// The split is driven via Raft: a `KvCommand::Split` is proposed through the
+/// source shard's log, so every node applies the data movement deterministically.
+/// The new shard's Raft group is then bootstrapped with the source membership.
 pub struct SplitCoordinator {
     router: Arc<ShardRouter>,
     shard_map: Arc<ShardMap>,
-    store: Arc<FjallStore>,
-    fsm: Arc<FjallStateMachine>,
-    node_id: u64,
-    cluster_addr: String,
-    heartbeat_ms: u64,
-    election_min_ms: u64,
-    election_max_ms: u64,
-    snapshot_threshold: u64,
 }
 
 impl SplitCoordinator {
@@ -61,14 +36,6 @@ impl SplitCoordinator {
         SplitCoordinator {
             router: cfg.router,
             shard_map: cfg.shard_map,
-            store: cfg.store,
-            fsm: cfg.fsm,
-            node_id: cfg.node_id,
-            cluster_addr: cfg.cluster_addr,
-            heartbeat_ms: cfg.heartbeat_ms,
-            election_min_ms: cfg.election_min_ms,
-            election_max_ms: cfg.election_max_ms,
-            snapshot_threshold: cfg.snapshot_threshold,
         }
     }
 
@@ -102,7 +69,7 @@ impl SplitCoordinator {
             ));
         }
 
-        // 2. Mark source shard as Splitting
+        // 2. Mark source shard as Splitting (blocks writes via router).
         let splitting_info = ShardInfo {
             shard_id,
             range: source_info.range.clone(),
@@ -110,28 +77,30 @@ impl SplitCoordinator {
         };
         self.shard_map.put_shard(splitting_info).await?;
 
-        // From here on, if we fail, we need to restore the source shard to Active.
+        // 3. Execute the split.
+        // do_split() returns Err only if the KvCommand::Split was NOT committed to
+        // the Raft log (pre-commit failures). Once the command is committed the
+        // ShardMap is already updated by apply() on every node, so on post-commit
+        // failures do_split() logs a warning and returns Ok (the split is done).
         let result = self.do_split(shard_id, split_key, &source_info).await;
 
-        match result {
-            Ok(new_shard_id) => Ok(new_shard_id),
-            Err(e) => {
-                // Restore source shard to Active on failure
-                tracing::error!(
-                    shard_id,
-                    split_key,
-                    error = %e,
-                    "split failed, restoring source shard to Active"
-                );
-                let restored = ShardInfo {
-                    shard_id,
-                    range: source_info.range.clone(),
-                    state: ShardState::Active,
-                };
-                let _ = self.shard_map.put_shard(restored).await;
-                Err(e)
-            }
+        if let Err(ref e) = result {
+            // The Raft propose failed — the split was not applied. Restore source.
+            tracing::error!(
+                shard_id,
+                split_key,
+                error = %e,
+                "split failed before commit, restoring source shard to Active"
+            );
+            let restored = ShardInfo {
+                shard_id,
+                range: source_info.range.clone(),
+                state: ShardState::Active,
+            };
+            let _ = self.shard_map.put_shard(restored).await;
         }
+
+        result
     }
 
     async fn do_split(
@@ -140,103 +109,115 @@ impl SplitCoordinator {
         split_key: &str,
         source_info: &ShardInfo,
     ) -> Result<ShardId, GgapError> {
-        // 3. Write barrier: propose a no-op through the source shard's Raft
+        // 1. Get source node's Raft handle.
         let source_node = self
             .router
             .get_node(shard_id)
             .await
             .ok_or(GgapError::ShardNotFound(shard_id))?;
 
-        // Use a Put with empty key as a barrier — just ensure linearizability
-        source_node
-            .raft()
-            .ensure_linearizable()
-            .await
-            .map_err(|e| GgapError::Consensus(format!("write barrier failed: {e}")))?;
+        // 2. Read source shard membership from Raft metrics.
+        let source_members: BTreeMap<u64, BasicNode> = {
+            let metrics = source_node.raft().metrics().borrow().clone();
+            metrics
+                .membership_config
+                .membership()
+                .nodes()
+                .map(|(id, node)| (*id, node.clone()))
+                .collect()
+        };
 
-        // 4. Build partial snapshot of keys >= split_key
-        let contents = self.fsm.build_partial_snapshot(shard_id, split_key).await?;
-
-        // 5. Allocate new shard id
+        // 3. Allocate new shard id.
         let new_shard_id = self.shard_map.next_shard_id().await;
 
-        // 6. Install partial snapshot on new shard
-        self.fsm
-            .install_partial_snapshot(new_shard_id, &contents)
-            .await?;
-
-        // 7. Delete transferred keys from source shard
-        self.fsm.delete_range_from(shard_id, split_key).await?;
-
-        // 8. Update ShardMap: narrow source, add new shard
-        let updated_source = ShardInfo {
-            shard_id,
-            range: KeyRange {
-                start: source_info.range.start.clone(),
-                end: split_key.to_string(),
-            },
-            state: ShardState::Active,
+        // 4. Propose KvCommand::Split through the source shard's Raft log.
+        //    This is the write barrier: ordered after all prior writes.
+        //    Every node's apply() will:
+        //      a) Move keys >= split_key to new_shard_id
+        //      b) Delete those keys from source shard
+        //      c) Update ShardMap (narrow source, add new shard)
+        //      d) Signal the background split handler via SplitApplied channel
+        let cmd = KvCommand::Split {
+            split_key: split_key.to_string(),
+            new_shard_id,
+            source_range: source_info.range.clone(),
         };
-        let new_shard = ShardInfo {
-            shard_id: new_shard_id,
-            range: KeyRange {
-                start: split_key.to_string(),
-                end: source_info.range.end.clone(),
-            },
-            state: ShardState::Active,
+        let write_result = source_node
+            .raft()
+            .client_write(cmd)
+            .await
+            .map_err(|e| {
+                if let Some(fwd) = e.forward_to_leader() {
+                    let leader_addr =
+                        fwd.leader_node.as_ref().map(|n: &BasicNode| n.addr.clone());
+                    return GgapError::NotLeader {
+                        leader: leader_addr,
+                    };
+                }
+                GgapError::Consensus(format!("Split propose failed: {e}"))
+            })?;
+
+        // Validate the response.
+        match write_result.data {
+            KvResponse::SplitComplete { new_shard_id: id } if id == new_shard_id => {}
+            ref other => {
+                return Err(GgapError::Consensus(format!(
+                    "unexpected response from Split command: {other:?}"
+                )));
+            }
+        }
+
+        // ── The Split command is now committed. The ShardMap has been updated on
+        //    every node that has applied the entry. From here, post-commit failures
+        //    are logged as warnings but do not cause a rollback (the data is split). ──
+
+        // 5. Wait for the new shard's Raft instance to appear in the router.
+        //    The background split handler creates it after receiving SplitApplied.
+        let new_node = {
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+            loop {
+                if let Some(node) = self.router.get_node(new_shard_id).await {
+                    break node;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    tracing::warn!(
+                        shard_id,
+                        new_shard_id,
+                        "timed out waiting for new shard Raft instance in router"
+                    );
+                    return Ok(new_shard_id);
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
         };
-        self.shard_map.put_shard(updated_source).await?;
-        self.shard_map.put_shard(new_shard).await?;
 
-        // 9. Bootstrap new Raft group for the new shard
-        let log_store = GgapLogStorage::new(FjallLogStorage(self.store.clone()), new_shard_id);
-        let sm = GgapStateMachine::new(self.fsm.clone(), new_shard_id);
-        let net = GgapNetworkFactory::new(new_shard_id);
-        let cfg = build_raft_config(
-            self.heartbeat_ms,
-            self.election_min_ms,
-            self.election_max_ms,
-            self.snapshot_threshold,
-        );
+        // 6. Initialize new shard's Raft with source membership.
+        //    openraft retries will handle followers whose background handler hasn't
+        //    created the Raft instance yet.
+        if let Err(e) = new_node.raft().initialize(source_members).await {
+            tracing::warn!(
+                shard_id,
+                new_shard_id,
+                error = %e,
+                "failed to initialize new shard Raft (will retry on next split attempt)"
+            );
+            return Ok(new_shard_id);
+        }
 
-        let raft = Arc::new(
-            GgapRaft::new(self.node_id, cfg, net, log_store, sm)
-                .await
-                .map_err(|e| {
-                    GgapError::Consensus(format!("failed to create Raft for new shard: {e}"))
-                })?,
-        );
-
-        // Initialize as single-node cluster
-        let mut members = BTreeMap::new();
-        members.insert(
-            self.node_id,
-            BasicNode {
-                addr: self.cluster_addr.clone(),
-            },
-        );
-        raft.initialize(members).await.map_err(|e| {
-            GgapError::Consensus(format!("failed to initialize new shard Raft: {e}"))
-        })?;
-
-        // Wait for the new shard to become leader
-        raft.wait(Some(Duration::from_secs(5)))
+        // 7. Wait for new shard leader election.
+        if let Err(e) = new_node
+            .raft()
+            .wait(Some(Duration::from_secs(10)))
             .state(ServerState::Leader, "new shard become leader")
             .await
-            .map_err(|e| GgapError::Consensus(format!("new shard did not become leader: {e}")))?;
-
-        // 10. Register in router
-        let new_node = Arc::new(OpenRaftNode::new(
-            raft.clone(),
-            self.fsm.clone(),
-            new_shard_id,
-            self.node_id,
-            tokio::time::Duration::from_millis(self.election_min_ms.saturating_sub(1)),
-        ));
-        let new_cluster = Arc::new(OpenRaftCluster::new(raft));
-        self.router
-            .add_shard(new_shard_id, new_node, new_cluster)
-            .await;
+        {
+            tracing::warn!(
+                shard_id,
+                new_shard_id,
+                error = %e,
+                "new shard did not elect a leader within timeout"
+            );
+        }
 
         tracing::info!(
             shard_id,
@@ -246,5 +227,59 @@ impl SplitCoordinator {
         );
 
         Ok(new_shard_id)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Background split handler — spawned on every node
+// ---------------------------------------------------------------------------
+
+/// Background task that runs on every node. When a `KvCommand::Split` is applied,
+/// `FjallStateMachine::apply()` sends a `SplitApplied` event through the channel.
+/// This task receives the event and bootstraps the new shard's Raft group,
+/// then registers it in the router.
+pub async fn run_split_handler(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<SplitApplied>,
+    store: Arc<FjallStore>,
+    fsm: Arc<FjallStateMachine>,
+    router: Arc<ShardRouter>,
+    node_id: u64,
+    raft_config: Arc<openraft::Config>,
+) {
+    while let Some(event) = rx.recv().await {
+        let new_shard_id = event.new_shard_id;
+        tracing::info!(new_shard_id, "background split handler: bootstrapping new shard");
+
+        let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), new_shard_id);
+        let sm = GgapStateMachine::new(fsm.clone(), new_shard_id);
+        let net = GgapNetworkFactory::new(new_shard_id);
+
+        let raft = match GgapRaft::new(node_id, raft_config.clone(), net, log_store, sm).await {
+            Ok(r) => Arc::new(r),
+            Err(e) => {
+                tracing::error!(
+                    new_shard_id,
+                    error = %e,
+                    "failed to create Raft for new shard in background handler"
+                );
+                continue;
+            }
+        };
+
+        let node = Arc::new(OpenRaftNode::new(
+            raft.clone(),
+            fsm.clone(),
+            new_shard_id,
+            node_id,
+            // Lease duration of zero — the coordinator will initialize membership.
+            tokio::time::Duration::from_secs(0),
+        ));
+        let cluster = Arc::new(OpenRaftCluster::new(raft));
+        router.add_shard(new_shard_id, node, cluster).await;
+
+        tracing::info!(
+            new_shard_id,
+            "background split handler: new shard registered in router"
+        );
     }
 }

--- a/crates/ggap-consensus/src/split.rs
+++ b/crates/ggap-consensus/src/split.rs
@@ -141,6 +141,10 @@ impl SplitCoordinator {
             split_key: split_key.to_string(),
             new_shard_id,
             source_range: source_info.range.clone(),
+            source_members: source_members
+                .iter()
+                .map(|(id, node)| (*id, node.addr.clone()))
+                .collect(),
         };
         let write_result = source_node
             .raft()

--- a/crates/ggap-node/Cargo.toml
+++ b/crates/ggap-node/Cargo.toml
@@ -22,3 +22,4 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
+bincode = { workspace = true }

--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -20,6 +20,7 @@ use tokio_util::sync::CancellationToken;
 
 use ggap_storage::{
     fjall::{FjallLogStorage, FjallStateMachine, FjallStore},
+    keys::meta_key,
     ttl::TtlGcTask,
     ShardMap,
 };
@@ -207,19 +208,39 @@ async fn main() -> anyhow::Result<()> {
                 .with_context(|| format!("failed to create Raft for shard {shard_id}"))?,
         );
 
-        // Initialize as single-node cluster on first boot (only for shard 0 initially).
+        // Initialize Raft membership on first boot.
+        // - Shard 0 (and any shard created before this fix): single-node bootstrap.
+        // - Split-created shards: read membership from bootstrap_members key written
+        //   atomically with the split data movement. This prevents a restarted node
+        //   from re-initializing as a single-node cluster, discarding replication.
         if !raft
             .is_initialized()
             .await
             .with_context(|| format!("raft.is_initialized failed for shard {shard_id}"))?
         {
-            let mut members = BTreeMap::new();
-            members.insert(
-                cli.node_id,
-                BasicNode {
-                    addr: cluster_addr.to_string(),
-                },
-            );
+            let bootstrap_key = meta_key(shard_id, "bootstrap_members");
+            let members: BTreeMap<u64, BasicNode> = match store.meta.get(&bootstrap_key) {
+                Ok(Some(bytes)) => {
+                    let (addr_map, _): (BTreeMap<u64, String>, _) =
+                        bincode::serde::decode_from_slice(&bytes, bincode::config::standard())
+                            .with_context(|| {
+                                format!("failed to decode bootstrap_members for shard {shard_id}")
+                            })?;
+                    addr_map
+                        .into_iter()
+                        .map(|(id, addr)| (id, BasicNode { addr }))
+                        .collect()
+                }
+                Ok(None) => {
+                    // Original shard or pre-fix split: fall back to single-node init.
+                    BTreeMap::from([(cli.node_id, BasicNode { addr: cluster_addr.to_string() })])
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to read bootstrap_members for shard {shard_id}: {e}"
+                    ));
+                }
+            };
             raft.initialize(members)
                 .await
                 .map_err(|e| anyhow::anyhow!("raft.initialize failed for shard {shard_id}: {e}"))?;

--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -233,7 +233,12 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Ok(None) => {
                     // Original shard or pre-fix split: fall back to single-node init.
-                    BTreeMap::from([(cli.node_id, BasicNode { addr: cluster_addr.to_string() })])
+                    BTreeMap::from([(
+                        cli.node_id,
+                        BasicNode {
+                            addr: cluster_addr.to_string(),
+                        },
+                    )])
                 }
                 Err(e) => {
                     return Err(anyhow::anyhow!(

--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -11,8 +11,9 @@ use openraft::BasicNode;
 use serde::Deserialize;
 
 use ggap_consensus::{
-    build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
+    build_raft_config, run_split_handler, GgapLogStorage, GgapNetworkFactory, GgapRaft,
+    GgapStateMachine, OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator,
+    SplitCoordinatorConfig,
 };
 use ggap_server::{serve_client, serve_cluster, KvServiceConfig};
 use tokio_util::sync::CancellationToken;
@@ -170,7 +171,16 @@ async fn main() -> anyhow::Result<()> {
     // 3. Create watch broadcast channel and FSM (shared across all shards).
     let (watch_tx, _watch_rx) =
         tokio::sync::broadcast::channel::<DomainWatchEvent>(config.server.watch_broadcast_capacity);
-    let fsm = Arc::new(FjallStateMachine::new(store.clone()).with_watch(watch_tx.clone()));
+
+    // Create split-event channel: FjallStateMachine sends SplitApplied events when
+    // a KvCommand::Split is applied; run_split_handler receives them and bootstraps
+    // the new shard's Raft group on this node.
+    let (split_tx, split_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let mut fsm_builder = FjallStateMachine::new(store.clone()).with_watch(watch_tx.clone());
+    fsm_builder.set_split_sender(split_tx);
+    fsm_builder.set_shard_map(shard_map.clone());
+    let fsm = Arc::new(fsm_builder);
 
     // 4. Create ShardRouter.
     let router = Arc::new(ShardRouter::new(shard_map.clone()));
@@ -245,21 +255,25 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!(shard_id, "started Raft group");
     }
 
-    // 6. Create the SplitCoordinator.
+    // 6. Spawn the background split handler.
+    //    Receives SplitApplied events from FjallStateMachine::apply() and
+    //    bootstraps the new shard's Raft group + registers it in the router.
+    tokio::spawn(run_split_handler(
+        split_rx,
+        store.clone(),
+        fsm.clone(),
+        router.clone(),
+        cli.node_id,
+        raft_cfg.clone(),
+    ));
+
+    // 7. Create the SplitCoordinator.
     let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
         router: router.clone(),
         shard_map: shard_map.clone(),
-        store: store.clone(),
-        fsm: fsm.clone(),
-        node_id: cli.node_id,
-        cluster_addr: cluster_addr.to_string(),
-        heartbeat_ms: config.raft.heartbeat_interval_ms,
-        election_min_ms: config.raft.election_timeout_min_ms,
-        election_max_ms: config.raft.election_timeout_max_ms,
-        snapshot_threshold: config.raft.snapshot_threshold,
     }));
 
-    // 7. Serve with graceful shutdown on SIGINT / SIGTERM.
+    // 8. Serve with graceful shutdown on SIGINT / SIGTERM.
     let kv_config = KvServiceConfig {
         max_key_bytes: config.storage.max_key_bytes,
         max_value_bytes: config.storage.max_value_bytes,

--- a/crates/ggap-server/benches/kv_write.rs
+++ b/crates/ggap-server/benches/kv_write.rs
@@ -88,14 +88,6 @@ async fn start_node(id: u64) -> BenchNode {
     let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
         router: router.clone(),
         shard_map: shard_map.clone(),
-        store,
-        fsm,
-        node_id: id,
-        cluster_addr: cluster_addr.to_string(),
-        heartbeat_ms: HEARTBEAT_MS,
-        election_min_ms: ELECTION_MIN_MS,
-        election_max_ms: ELECTION_MAX_MS,
-        snapshot_threshold: 50_000,
     }));
 
     let mut handles = Vec::new();

--- a/crates/ggap-server/tests/split_single_node.rs
+++ b/crates/ggap-server/tests/split_single_node.rs
@@ -53,9 +53,15 @@ async fn setup() -> TestSetup {
     let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
     let sm = GgapStateMachine::new(fsm.clone(), 0);
     let raft = Arc::new(
-        GgapRaft::new(1, raft_cfg.clone(), GgapNetworkFactory::new(0), log_store, sm)
-            .await
-            .unwrap(),
+        GgapRaft::new(
+            1,
+            raft_cfg.clone(),
+            GgapNetworkFactory::new(0),
+            log_store,
+            sm,
+        )
+        .await
+        .unwrap(),
     );
 
     // Initialize as single-node cluster.

--- a/crates/ggap-server/tests/split_single_node.rs
+++ b/crates/ggap-server/tests/split_single_node.rs
@@ -14,8 +14,9 @@ use openraft::{BasicNode, ServerState};
 use tempfile::TempDir;
 
 use ggap_consensus::{
-    build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
+    build_raft_config, run_split_handler, GgapLogStorage, GgapNetworkFactory, GgapRaft,
+    GgapStateMachine, OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator,
+    SplitCoordinatorConfig,
 };
 use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
 use ggap_storage::traits::StateMachineStore;
@@ -35,12 +36,24 @@ struct TestSetup {
 async fn setup() -> TestSetup {
     let tempdir = TempDir::new().unwrap();
     let store = FjallStore::open(tempdir.path()).unwrap();
-    let fsm = Arc::new(FjallStateMachine::new(store.clone()));
+
+    // ShardMap must be created before FSM so we can pass it in.
+    let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
+    shard_map.initialize_default().await.unwrap();
+
+    // Split channel: FjallStateMachine sends events; background handler receives them.
+    let (split_tx, split_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let mut fsm_builder = FjallStateMachine::new(store.clone());
+    fsm_builder.set_split_sender(split_tx);
+    fsm_builder.set_shard_map(shard_map.clone());
+    let fsm = Arc::new(fsm_builder);
+
+    let raft_cfg = build_raft_config(50, 150, 300, 500);
     let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
     let sm = GgapStateMachine::new(fsm.clone(), 0);
-    let cfg = build_raft_config(50, 150, 300, 500);
     let raft = Arc::new(
-        GgapRaft::new(1, cfg, GgapNetworkFactory::new(0), log_store, sm)
+        GgapRaft::new(1, raft_cfg.clone(), GgapNetworkFactory::new(0), log_store, sm)
             .await
             .unwrap(),
     );
@@ -56,9 +69,6 @@ async fn setup() -> TestSetup {
         .await
         .unwrap();
 
-    let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
-    shard_map.initialize_default().await.unwrap();
-
     let router = Arc::new(ShardRouter::new(shard_map.clone()));
     let node = Arc::new(OpenRaftNode::new(
         raft.clone(),
@@ -70,17 +80,19 @@ async fn setup() -> TestSetup {
     let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
     router.add_shard(0, node, cluster).await;
 
+    // Spawn background split handler: creates new shard Raft instances on split events.
+    tokio::spawn(run_split_handler(
+        split_rx,
+        store.clone(),
+        fsm.clone(),
+        router.clone(),
+        1, // node_id
+        raft_cfg,
+    ));
+
     let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
         router: router.clone(),
         shard_map: shard_map.clone(),
-        store,
-        fsm: fsm.clone(),
-        node_id: 1,
-        cluster_addr: "127.0.0.1:0".into(), // unused for single-node
-        heartbeat_ms: 50,
-        election_min_ms: 150,
-        election_max_ms: 300,
-        snapshot_threshold: 500,
     }));
 
     TestSetup {

--- a/crates/ggap-server/tests/three_node_cluster.rs
+++ b/crates/ggap-server/tests/three_node_cluster.rs
@@ -65,9 +65,15 @@ async fn start_node(id: u64) -> TestNode {
     // Fast timeouts so tests finish quickly.
     let raft_cfg = build_raft_config(50, 150, 300, 500);
     let raft = Arc::new(
-        GgapRaft::new(id, raft_cfg.clone(), GgapNetworkFactory::new(0), log_store, sm)
-            .await
-            .unwrap_or_else(|e| panic!("node {id}: raft init failed: {e}")),
+        GgapRaft::new(
+            id,
+            raft_cfg.clone(),
+            GgapNetworkFactory::new(0),
+            log_store,
+            sm,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("node {id}: raft init failed: {e}")),
     );
 
     // Pre-bind on port 0 → OS picks a free port we can pass to BasicNode.

--- a/crates/ggap-server/tests/three_node_cluster.rs
+++ b/crates/ggap-server/tests/three_node_cluster.rs
@@ -18,8 +18,9 @@ use tempfile::TempDir;
 use tokio::net::TcpListener;
 
 use ggap_consensus::{
-    build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
+    build_raft_config, run_split_handler, GgapLogStorage, GgapNetworkFactory, GgapRaft,
+    GgapStateMachine, OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator,
+    SplitCoordinatorConfig,
 };
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener, KvServiceConfig};
 use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
@@ -46,13 +47,25 @@ struct TestNode {
 async fn start_node(id: u64) -> TestNode {
     let tempdir = TempDir::new().unwrap();
     let store = FjallStore::open(tempdir.path()).unwrap();
-    let fsm = Arc::new(FjallStateMachine::new(store.clone()));
+
+    // ShardMap created before FSM so we can inject it.
+    let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
+    shard_map.initialize_default().await.unwrap();
+
+    // Split channel: state machine signals background handler on apply.
+    let (split_tx, split_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let mut fsm_builder = FjallStateMachine::new(store.clone());
+    fsm_builder.set_split_sender(split_tx);
+    fsm_builder.set_shard_map(shard_map.clone());
+    let fsm = Arc::new(fsm_builder);
+
     let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
     let sm = GgapStateMachine::new(fsm.clone(), 0);
     // Fast timeouts so tests finish quickly.
-    let cfg = build_raft_config(50, 150, 300, 500);
+    let raft_cfg = build_raft_config(50, 150, 300, 500);
     let raft = Arc::new(
-        GgapRaft::new(id, cfg, GgapNetworkFactory::new(0), log_store, sm)
+        GgapRaft::new(id, raft_cfg.clone(), GgapNetworkFactory::new(0), log_store, sm)
             .await
             .unwrap_or_else(|e| panic!("node {id}: raft init failed: {e}")),
     );
@@ -72,22 +85,22 @@ async fn start_node(id: u64) -> TestNode {
     let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
 
     // Build a single-shard router for this node.
-    let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
-    shard_map.initialize_default().await.unwrap();
     let router = Arc::new(ShardRouter::new(shard_map.clone()));
     router.add_shard(0, raft_node.clone(), cluster).await;
+
+    // Spawn background split handler.
+    tokio::spawn(run_split_handler(
+        split_rx,
+        store.clone(),
+        fsm.clone(),
+        router.clone(),
+        id,
+        raft_cfg,
+    ));
 
     let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
         router: router.clone(),
         shard_map: shard_map.clone(),
-        store,
-        fsm: fsm.clone(),
-        node_id: id,
-        cluster_addr: cluster_addr.to_string(),
-        heartbeat_ms: 50,
-        election_min_ms: 150,
-        election_max_ms: 300,
-        snapshot_threshold: 500,
     }));
 
     let mut handles = Vec::new();

--- a/crates/ggap-storage/Cargo.toml
+++ b/crates/ggap-storage/Cargo.toml
@@ -3,6 +3,11 @@ name = "ggap-storage"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Enables crash-injection helpers used by integration tests. Never enable in
+# production builds.
+test-utils = []
+
 [dependencies]
 ggap-types = { path = "../ggap-types" }
 thiserror = { workspace = true }
@@ -17,3 +22,4 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+bincode = { workspace = true }

--- a/crates/ggap-storage/Cargo.toml
+++ b/crates/ggap-storage/Cargo.toml
@@ -20,6 +20,10 @@ tracing = { workspace = true }
 bytes = { workspace = true }
 uuid = { workspace = true }
 
+[[test]]
+name = "split_crash_bugs"
+required-features = ["test-utils"]
+
 [dev-dependencies]
 tempfile = "3"
 bincode = { workspace = true }

--- a/crates/ggap-storage/src/fjall.rs
+++ b/crates/ggap-storage/src/fjall.rs
@@ -517,9 +517,7 @@ impl StateMachineStore for FjallStateMachine {
                 .crash_after_phase1
                 .load(std::sync::atomic::Ordering::SeqCst)
             {
-                return Err(GgapError::Storage(
-                    "simulated crash after phase 1".into(),
-                ));
+                return Err(GgapError::Storage("simulated crash after phase 1".into()));
             }
 
             // Update in-memory ShardMap cache only — storage was already written
@@ -1070,11 +1068,10 @@ pub(crate) fn build_partial_snapshot_sync(
                 })?;
                 let user_key = String::from_utf8(raw[..null_pos].to_vec())
                     .map_err(|e| GgapError::Storage(e.to_string()))?;
-                let version = u64::from_be_bytes(
-                    raw[null_pos + 1..null_pos + 9]
-                        .try_into()
-                        .map_err(|_| GgapError::Storage("malformed history key: short version".into()))?,
-                );
+                let version =
+                    u64::from_be_bytes(raw[null_pos + 1..null_pos + 9].try_into().map_err(
+                        |_| GgapError::Storage("malformed history key: short version".into()),
+                    )?);
                 Ok(((user_key, version), decode::<KvEntry>(&v)?))
             })
         })
@@ -1129,13 +1126,16 @@ pub(crate) fn install_into_batch(
     Ok(())
 }
 
+/// Raw storage keys to delete: (data_keys, history_keys, ttl_keys).
+type RangeDeleteKeys = (Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<Vec<u8>>);
+
 /// Collect all raw storage keys `>= from_key` for `shard_id` across data,
 /// history, and ttl_index. Returns (data_keys, history_keys, ttl_keys).
 pub(crate) fn collect_range_deletes(
     store: &FjallStore,
     shard_id: ShardId,
     from_key: &str,
-) -> Result<(Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<Vec<u8>>), GgapError> {
+) -> Result<RangeDeleteKeys, GgapError> {
     let start = data_key(shard_id, from_key);
     let shard_end = data_shard_end(shard_id).to_vec();
 
@@ -1228,9 +1228,11 @@ impl FjallStateMachine {
     ) -> Result<SnapshotContents, GgapError> {
         let store = self.store.clone();
         let split_key = split_key.to_string();
-        tokio::task::spawn_blocking(move || build_partial_snapshot_sync(&store, shard_id, &split_key))
-            .await
-            .map_err(|e| GgapError::Storage(e.to_string()))?
+        tokio::task::spawn_blocking(move || {
+            build_partial_snapshot_sync(&store, shard_id, &split_key)
+        })
+        .await
+        .map_err(|e| GgapError::Storage(e.to_string()))?
     }
 
     /// Install a partial snapshot into a new shard.

--- a/crates/ggap-storage/src/fjall.rs
+++ b/crates/ggap-storage/src/fjall.rs
@@ -10,7 +10,7 @@ use tracing::warn;
 use crate::keys::{
     data_key, data_shard_end, history_key, history_prefix, meta_key, raft_log_key, ttl_index_key,
 };
-use crate::shard_map::ShardMap;
+use crate::shard_map::{bootstrap_members_key, encode as sm_encode, shard_map_key, ShardMap};
 use crate::traits::{LogStorage, StateMachineStore};
 use crate::types::{LogEntry, LogState, Snapshot, SnapshotContents, SnapshotMeta, Vote};
 
@@ -427,34 +427,92 @@ impl StateMachineStore for FjallStateMachine {
             ref split_key,
             new_shard_id,
             ref source_range,
+            ref source_members,
         }) = cmd
         {
             let store = self.store.clone();
             let split_key = split_key.clone();
             let source_range = source_range.clone();
-            // Clone again for use after the spawn_blocking (split_key is moved in).
+            let source_members = source_members.clone();
+            // Keep copies for the in-memory cache update after spawn_blocking.
             let split_key_post = split_key.clone();
+            let source_range_post = source_range.clone();
 
-            // Phase 1: synchronous data movement inside spawn_blocking.
-            tokio::task::spawn_blocking(move || -> Result<(), GgapError> {
+            // Single atomic spawn_blocking: reads, then one batch.commit() covering
+            // data movement + last_applied + ShardMap entries + bootstrap_members.
+            // A crash at any point leaves the store consistent: either all of these
+            // are visible on restart, or none are (last_applied not advanced →
+            // Raft re-applies the entry on the next leader).
+            tokio::task::spawn_blocking(move || -> Result<(ShardInfo, ShardInfo), GgapError> {
+                // Read phase (no writes yet).
                 let contents = build_partial_snapshot_sync(&store, shard_id, &split_key)?;
-                install_partial_snapshot_sync(&store, new_shard_id, &contents)?;
-                delete_range_from_sync(&store, shard_id, &split_key)?;
+                let (del_data, del_history, del_ttl) =
+                    collect_range_deletes(&store, shard_id, &split_key)?;
 
-                // Advance last_applied atomically with the data movement.
+                let updated_source = ShardInfo {
+                    shard_id,
+                    range: KeyRange {
+                        start: source_range.start.clone(),
+                        end: split_key.clone(),
+                    },
+                    state: ShardState::Active,
+                };
+                let new_shard = ShardInfo {
+                    shard_id: new_shard_id,
+                    range: KeyRange {
+                        start: split_key.clone(),
+                        end: source_range.end.clone(),
+                    },
+                    state: ShardState::Active,
+                };
+
+                // Single atomic batch: all or nothing.
                 let mut batch = store.db.batch();
+
+                // 1. Copy upper-half data to new shard.
+                install_into_batch(&mut batch, &store, new_shard_id, &contents)?;
+
+                // 2. Delete upper-half from source shard.
+                delete_range_into_batch(&mut batch, &store, del_data, del_history, del_ttl);
+
+                // 3. Advance last_applied for the source shard.
                 batch.insert(
                     &store.meta,
                     meta_key(shard_id, "last_applied"),
                     encode(&log_id)?,
                 );
-                batch.commit().map_err(fjall_err)
+
+                // 4. Persist updated source ShardMap entry (narrowed range).
+                batch.insert(
+                    &store.meta,
+                    shard_map_key(shard_id),
+                    sm_encode(&updated_source)?,
+                );
+
+                // 5. Persist new shard ShardMap entry.
+                batch.insert(
+                    &store.meta,
+                    shard_map_key(new_shard_id),
+                    sm_encode(&new_shard)?,
+                );
+
+                // 6. Persist bootstrap membership for the new shard so that on
+                //    restart main.rs can initialise it with the correct peers.
+                batch.insert(
+                    &store.meta,
+                    bootstrap_members_key(new_shard_id),
+                    encode(&source_members)?,
+                );
+
+                batch.commit().map_err(fjall_err)?;
+                Ok((updated_source, new_shard))
             })
             .await
             .map_err(|e| GgapError::Storage(e.to_string()))??;
 
-            // Fault injection: simulate a crash after Phase 1 commits but before Phase 2.
-            // The flag is never armed in production (arm_crash_after_phase1 is test-only).
+            // Fault injection: armed in tests to verify the pre-fix buggy state.
+            // After the fix above this point is never reached with inconsistent state,
+            // but the check is kept so existing repro tests document the old boundary.
             if self
                 .crash_after_phase1
                 .load(std::sync::atomic::Ordering::SeqCst)
@@ -464,12 +522,14 @@ impl StateMachineStore for FjallStateMachine {
                 ));
             }
 
-            // Phase 2: update ShardMap in-memory cache (async).
+            // Update in-memory ShardMap cache only — storage was already written
+            // atomically in the batch above. Do not call put_shard() (which would
+            // double-write to fjall).
             if let Some(ref sm) = self.shard_map {
                 let updated_source = ShardInfo {
                     shard_id,
                     range: KeyRange {
-                        start: source_range.start.clone(),
+                        start: source_range_post.start.clone(),
                         end: split_key_post.clone(),
                     },
                     state: ShardState::Active,
@@ -478,15 +538,14 @@ impl StateMachineStore for FjallStateMachine {
                     shard_id: new_shard_id,
                     range: KeyRange {
                         start: split_key_post.clone(),
-                        end: source_range.end.clone(),
+                        end: source_range_post.end.clone(),
                     },
                     state: ShardState::Active,
                 };
-                sm.put_shard(updated_source).await?;
-                sm.put_shard(new_shard).await?;
+                sm.update_cache_after_split(updated_source, new_shard).await;
             }
 
-            // Phase 3: signal background split handler.
+            // Signal background split handler.
             if let Some(ref tx) = self.split_tx {
                 let _ = tx.send(SplitApplied { new_shard_id });
             }
@@ -1035,6 +1094,17 @@ pub(crate) fn install_partial_snapshot_sync(
     contents: &SnapshotContents,
 ) -> Result<(), GgapError> {
     let mut batch = store.db.batch();
+    install_into_batch(&mut batch, store, new_shard_id, contents)?;
+    batch.commit().map_err(fjall_err)
+}
+
+/// Add snapshot install writes to an existing batch without committing.
+pub(crate) fn install_into_batch(
+    batch: &mut fjall::OwnedWriteBatch,
+    store: &FjallStore,
+    new_shard_id: ShardId,
+    contents: &SnapshotContents,
+) -> Result<(), GgapError> {
     for (user_key, entry) in &contents.data {
         batch.insert(
             &store.data,
@@ -1056,15 +1126,16 @@ pub(crate) fn install_partial_snapshot_sync(
             encode(entry)?,
         );
     }
-    batch.commit().map_err(fjall_err)
+    Ok(())
 }
 
-/// Delete all keys `>= from_key` from data, history, and ttl_index for `shard_id`.
-pub(crate) fn delete_range_from_sync(
+/// Collect all raw storage keys `>= from_key` for `shard_id` across data,
+/// history, and ttl_index. Returns (data_keys, history_keys, ttl_keys).
+pub(crate) fn collect_range_deletes(
     store: &FjallStore,
     shard_id: ShardId,
     from_key: &str,
-) -> Result<(), GgapError> {
+) -> Result<(Vec<Vec<u8>>, Vec<Vec<u8>>, Vec<Vec<u8>>), GgapError> {
     let start = data_key(shard_id, from_key);
     let shard_end = data_shard_end(shard_id).to_vec();
 
@@ -1110,7 +1181,29 @@ pub(crate) fn delete_range_from_sync(
         })
         .collect::<Result<_, _>>()?;
 
+    Ok((data_keys, history_keys, ttl_keys))
+}
+
+/// Delete all keys `>= from_key` from data, history, and ttl_index for `shard_id`.
+pub(crate) fn delete_range_from_sync(
+    store: &FjallStore,
+    shard_id: ShardId,
+    from_key: &str,
+) -> Result<(), GgapError> {
+    let (data_keys, history_keys, ttl_keys) = collect_range_deletes(store, shard_id, from_key)?;
     let mut batch = store.db.batch();
+    delete_range_into_batch(&mut batch, store, data_keys, history_keys, ttl_keys);
+    batch.commit().map_err(fjall_err)
+}
+
+/// Add range-delete writes to an existing batch without committing.
+pub(crate) fn delete_range_into_batch(
+    batch: &mut fjall::OwnedWriteBatch,
+    store: &FjallStore,
+    data_keys: Vec<Vec<u8>>,
+    history_keys: Vec<Vec<u8>>,
+    ttl_keys: Vec<Vec<u8>>,
+) {
     for k in data_keys {
         batch.remove(&store.data, k);
     }
@@ -1120,7 +1213,6 @@ pub(crate) fn delete_range_from_sync(
     for k in ttl_keys {
         batch.remove(&store.ttl_index, k);
     }
-    batch.commit().map_err(fjall_err)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ggap-storage/src/fjall.rs
+++ b/crates/ggap-storage/src/fjall.rs
@@ -2,14 +2,15 @@ use std::path::Path;
 use std::sync::Arc;
 
 use ggap_types::{
-    system_now_fn, DomainWatchEvent, GgapError, KvCommand, KvEntry, KvResponse, LogId, NowFn,
-    ShardId, WatchEventKind,
+    system_now_fn, DomainWatchEvent, GgapError, KeyRange, KvCommand, KvEntry, KvResponse, LogId,
+    NowFn, ShardId, ShardInfo, ShardState, WatchEventKind,
 };
 use tracing::warn;
 
 use crate::keys::{
     data_key, data_shard_end, history_key, history_prefix, meta_key, raft_log_key, ttl_index_key,
 };
+use crate::shard_map::ShardMap;
 use crate::traits::{LogStorage, StateMachineStore};
 use crate::types::{LogEntry, LogState, Snapshot, SnapshotContents, SnapshotMeta, Vote};
 
@@ -295,12 +296,28 @@ impl LogStorage for FjallLogStorage {
 // FjallStateMachine
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// SplitApplied — signal sent from apply() to background split handler
+// ---------------------------------------------------------------------------
+
+/// Sent through the split channel when a `KvCommand::Split` is successfully applied.
+/// The background handler on each node receives this and bootstraps the new Raft group.
+pub struct SplitApplied {
+    pub new_shard_id: ShardId,
+}
+
+// ---------------------------------------------------------------------------
+// FjallStateMachine
+// ---------------------------------------------------------------------------
+
 /// `StateMachineStore` backed by fjall.
 pub struct FjallStateMachine {
     pub(crate) store: Arc<FjallStore>,
     max_history_versions: u64,
     now_fn: NowFn,
     watch_tx: Option<tokio::sync::broadcast::Sender<DomainWatchEvent>>,
+    split_tx: Option<tokio::sync::mpsc::UnboundedSender<SplitApplied>>,
+    shard_map: Option<Arc<ShardMap>>,
 }
 
 impl FjallStateMachine {
@@ -310,6 +327,8 @@ impl FjallStateMachine {
             max_history_versions: DEFAULT_MAX_HISTORY,
             now_fn: system_now_fn(),
             watch_tx: None,
+            split_tx: None,
+            shard_map: None,
         }
     }
 
@@ -319,6 +338,8 @@ impl FjallStateMachine {
             max_history_versions,
             now_fn: system_now_fn(),
             watch_tx: None,
+            split_tx: None,
+            shard_map: None,
         }
     }
 
@@ -331,6 +352,19 @@ impl FjallStateMachine {
     pub fn with_watch(mut self, tx: tokio::sync::broadcast::Sender<DomainWatchEvent>) -> Self {
         self.watch_tx = Some(tx);
         self
+    }
+
+    /// Attach a split-event sender. When a `KvCommand::Split` is applied, the new
+    /// shard id is sent through this channel so that the background handler can
+    /// bootstrap the new Raft group on this node.
+    pub fn set_split_sender(&mut self, tx: tokio::sync::mpsc::UnboundedSender<SplitApplied>) {
+        self.split_tx = Some(tx);
+    }
+
+    /// Attach the ShardMap so the state machine can update shard ranges when
+    /// applying a `KvCommand::Split`.
+    pub fn set_shard_map(&mut self, shard_map: Arc<ShardMap>) {
+        self.shard_map = Some(shard_map);
     }
 }
 
@@ -370,6 +404,73 @@ impl StateMachineStore for FjallStateMachine {
         cmd: Option<KvCommand>,
         membership_bytes: Option<Vec<u8>>,
     ) -> Result<KvResponse, GgapError> {
+        // -----------------------------------------------------------------------
+        // Split command: handled separately to allow async ShardMap updates and
+        // split-channel signaling after the synchronous data movement.
+        // -----------------------------------------------------------------------
+        if let Some(KvCommand::Split {
+            ref split_key,
+            new_shard_id,
+            ref source_range,
+        }) = cmd
+        {
+            let store = self.store.clone();
+            let split_key = split_key.clone();
+            let source_range = source_range.clone();
+            // Clone again for use after the spawn_blocking (split_key is moved in).
+            let split_key_post = split_key.clone();
+
+            // Phase 1: synchronous data movement inside spawn_blocking.
+            tokio::task::spawn_blocking(move || -> Result<(), GgapError> {
+                let contents = build_partial_snapshot_sync(&store, shard_id, &split_key)?;
+                install_partial_snapshot_sync(&store, new_shard_id, &contents)?;
+                delete_range_from_sync(&store, shard_id, &split_key)?;
+
+                // Advance last_applied atomically with the data movement.
+                let mut batch = store.db.batch();
+                batch.insert(
+                    &store.meta,
+                    meta_key(shard_id, "last_applied"),
+                    encode(&log_id)?,
+                );
+                batch.commit().map_err(fjall_err)
+            })
+            .await
+            .map_err(|e| GgapError::Storage(e.to_string()))??;
+
+            // Phase 2: update ShardMap in-memory cache (async).
+            if let Some(ref sm) = self.shard_map {
+                let updated_source = ShardInfo {
+                    shard_id,
+                    range: KeyRange {
+                        start: source_range.start.clone(),
+                        end: split_key_post.clone(),
+                    },
+                    state: ShardState::Active,
+                };
+                let new_shard = ShardInfo {
+                    shard_id: new_shard_id,
+                    range: KeyRange {
+                        start: split_key_post.clone(),
+                        end: source_range.end.clone(),
+                    },
+                    state: ShardState::Active,
+                };
+                sm.put_shard(updated_source).await?;
+                sm.put_shard(new_shard).await?;
+            }
+
+            // Phase 3: signal background split handler.
+            if let Some(ref tx) = self.split_tx {
+                let _ = tx.send(SplitApplied { new_shard_id });
+            }
+
+            return Ok(KvResponse::SplitComplete { new_shard_id });
+        }
+
+        // -----------------------------------------------------------------------
+        // All other commands: handled inside a single spawn_blocking.
+        // -----------------------------------------------------------------------
         let store = self.store.clone();
         let max_history = self.max_history_versions;
         let now_fn = self.now_fn.clone();
@@ -596,6 +697,11 @@ impl StateMachineStore for FjallStateMachine {
                     );
                     batch.commit().map_err(fjall_err)?;
                     Ok(KvResponse::NoOp)
+                }
+                // Split is handled before this spawn_blocking block and never
+                // reaches here.
+                Some(KvCommand::Split { .. }) => {
+                    unreachable!("Split command must be handled before spawn_blocking")
                 }
             }
         })
@@ -842,12 +948,161 @@ impl StateMachineStore for FjallStateMachine {
 }
 
 // ---------------------------------------------------------------------------
-// Split helpers on FjallStateMachine
+// Split helpers — synchronous inner functions (callable from spawn_blocking)
+// ---------------------------------------------------------------------------
+
+/// Extract all keys `>= split_key` from `shard_id` into a `SnapshotContents`.
+pub(crate) fn build_partial_snapshot_sync(
+    store: &FjallStore,
+    shard_id: ShardId,
+    split_key: &str,
+) -> Result<SnapshotContents, GgapError> {
+    let start = data_key(shard_id, split_key);
+    let shard_end = data_shard_end(shard_id).to_vec();
+
+    let data: Vec<(String, KvEntry)> = store
+        .data
+        .range(start..shard_end.clone())
+        .map(|g| {
+            g.into_inner().map_err(fjall_err).and_then(|(k, v)| {
+                let user_key = String::from_utf8(k[8..].to_vec())
+                    .map_err(|e| GgapError::Storage(e.to_string()))?;
+                Ok((user_key, decode::<KvEntry>(&v)?))
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    // History: scan entire shard and filter by user key >= split_key
+    let shard_start = shard_id.to_be_bytes().to_vec();
+    let history: Vec<((String, u64), KvEntry)> = store
+        .history
+        .range(shard_start..shard_end)
+        .map(|g| {
+            g.into_inner().map_err(fjall_err).and_then(|(k, v)| {
+                let raw = &k[8..];
+                let null_pos = raw.iter().position(|&b| b == 0).ok_or_else(|| {
+                    GgapError::Storage("malformed history key: missing null byte".into())
+                })?;
+                let user_key = String::from_utf8(raw[..null_pos].to_vec())
+                    .map_err(|e| GgapError::Storage(e.to_string()))?;
+                let version = u64::from_be_bytes(
+                    raw[null_pos + 1..null_pos + 9]
+                        .try_into()
+                        .map_err(|_| GgapError::Storage("malformed history key: short version".into()))?,
+                );
+                Ok(((user_key, version), decode::<KvEntry>(&v)?))
+            })
+        })
+        .filter(|r| match r {
+            Ok(((ref user_key, _), _)) => user_key.as_str() >= split_key,
+            Err(_) => true, // propagate errors
+        })
+        .collect::<Result<_, _>>()?;
+
+    Ok(SnapshotContents { data, history })
+}
+
+/// Write `contents` into `new_shard_id`, creating TTL index entries as needed.
+pub(crate) fn install_partial_snapshot_sync(
+    store: &FjallStore,
+    new_shard_id: ShardId,
+    contents: &SnapshotContents,
+) -> Result<(), GgapError> {
+    let mut batch = store.db.batch();
+    for (user_key, entry) in &contents.data {
+        batch.insert(
+            &store.data,
+            data_key(new_shard_id, user_key),
+            encode(entry)?,
+        );
+        if let Some(expires_at_ns) = entry.expires_at_ns {
+            batch.insert(
+                &store.ttl_index,
+                ttl_index_key(new_shard_id, expires_at_ns, user_key),
+                Vec::new(),
+            );
+        }
+    }
+    for ((user_key, version), entry) in &contents.history {
+        batch.insert(
+            &store.history,
+            history_key(new_shard_id, user_key, *version),
+            encode(entry)?,
+        );
+    }
+    batch.commit().map_err(fjall_err)
+}
+
+/// Delete all keys `>= from_key` from data, history, and ttl_index for `shard_id`.
+pub(crate) fn delete_range_from_sync(
+    store: &FjallStore,
+    shard_id: ShardId,
+    from_key: &str,
+) -> Result<(), GgapError> {
+    let start = data_key(shard_id, from_key);
+    let shard_end = data_shard_end(shard_id).to_vec();
+
+    let data_keys: Vec<Vec<u8>> = store
+        .data
+        .range(start..shard_end.clone())
+        .map(|g| g.into_inner().map(|(k, _)| k.to_vec()).map_err(fjall_err))
+        .collect::<Result<_, _>>()?;
+
+    let shard_start = shard_id.to_be_bytes().to_vec();
+    let history_keys: Vec<Vec<u8>> = store
+        .history
+        .range(shard_start.clone()..shard_end.clone())
+        .filter_map(|g| match g.into_inner().map_err(fjall_err) {
+            Ok((k, _)) => {
+                let raw = &k[8..];
+                if let Some(null_pos) = raw.iter().position(|&b| b == 0) {
+                    let user_key_bytes = &raw[..null_pos];
+                    if user_key_bytes >= from_key.as_bytes() {
+                        return Some(Ok(k.to_vec()));
+                    }
+                }
+                None
+            }
+            Err(e) => Some(Err(e)),
+        })
+        .collect::<Result<_, _>>()?;
+
+    let ttl_keys: Vec<Vec<u8>> = store
+        .ttl_index
+        .range(shard_start..shard_end)
+        .filter_map(|g| match g.into_inner().map_err(fjall_err) {
+            Ok((k, _)) => {
+                // TTL key: shard(8) ++ expires_at_ns(8) ++ key_utf8
+                let user_key_bytes = &k[16..];
+                if user_key_bytes >= from_key.as_bytes() {
+                    Some(Ok(k.to_vec()))
+                } else {
+                    None
+                }
+            }
+            Err(e) => Some(Err(e)),
+        })
+        .collect::<Result<_, _>>()?;
+
+    let mut batch = store.db.batch();
+    for k in data_keys {
+        batch.remove(&store.data, k);
+    }
+    for k in history_keys {
+        batch.remove(&store.history, k);
+    }
+    for k in ttl_keys {
+        batch.remove(&store.ttl_index, k);
+    }
+    batch.commit().map_err(fjall_err)
+}
+
+// ---------------------------------------------------------------------------
+// Split helpers on FjallStateMachine (async wrappers for external callers)
 // ---------------------------------------------------------------------------
 
 impl FjallStateMachine {
     /// Build a snapshot containing only keys `>= split_key` within the shard.
-    /// Used during range splitting to extract the upper half of a shard.
     pub async fn build_partial_snapshot(
         &self,
         shard_id: ShardId,
@@ -855,97 +1110,27 @@ impl FjallStateMachine {
     ) -> Result<SnapshotContents, GgapError> {
         let store = self.store.clone();
         let split_key = split_key.to_string();
-        tokio::task::spawn_blocking(move || -> Result<SnapshotContents, GgapError> {
-            let start = data_key(shard_id, &split_key);
-            let shard_end = data_shard_end(shard_id).to_vec();
-
-            let data: Vec<(String, KvEntry)> = store
-                .data
-                .range(start..shard_end.clone())
-                .map(|g| {
-                    g.into_inner().map_err(fjall_err).and_then(|(k, v)| {
-                        let user_key = String::from_utf8(k[8..].to_vec())
-                            .map_err(|e| GgapError::Storage(e.to_string()))?;
-                        Ok((user_key, decode::<KvEntry>(&v)?))
-                    })
-                })
-                .collect::<Result<_, _>>()?;
-
-            // History: scan entire shard and filter by user key >= split_key
-            let shard_start = shard_id.to_be_bytes().to_vec();
-            let history: Vec<((String, u64), KvEntry)> = store
-                .history
-                .range(shard_start..shard_end)
-                .map(|g| {
-                    g.into_inner().map_err(fjall_err).and_then(|(k, v)| {
-                        let raw = &k[8..];
-                        let null_pos = raw.iter().position(|&b| b == 0).ok_or_else(|| {
-                            GgapError::Storage("malformed history key: missing null byte".into())
-                        })?;
-                        let user_key = String::from_utf8(raw[..null_pos].to_vec())
-                            .map_err(|e| GgapError::Storage(e.to_string()))?;
-                        let version = u64::from_be_bytes(
-                            raw[null_pos + 1..null_pos + 9].try_into().map_err(|_| {
-                                GgapError::Storage("malformed history key: short version".into())
-                            })?,
-                        );
-                        Ok(((user_key, version), decode::<KvEntry>(&v)?))
-                    })
-                })
-                .filter(|r| match r {
-                    Ok(((ref user_key, _), _)) => user_key.as_str() >= split_key.as_str(),
-                    Err(_) => true, // propagate errors
-                })
-                .collect::<Result<_, _>>()?;
-
-            Ok(SnapshotContents { data, history })
-        })
-        .await
-        .map_err(|e| GgapError::Storage(e.to_string()))?
+        tokio::task::spawn_blocking(move || build_partial_snapshot_sync(&store, shard_id, &split_key))
+            .await
+            .map_err(|e| GgapError::Storage(e.to_string()))?
     }
 
-    /// Install a partial snapshot into a new shard, writing keys with the
-    /// new shard_id prefix. Also copies TTL index entries.
+    /// Install a partial snapshot into a new shard.
     pub async fn install_partial_snapshot(
         &self,
         new_shard_id: ShardId,
         contents: &SnapshotContents,
     ) -> Result<(), GgapError> {
         let store = self.store.clone();
-        let data = contents.data.clone();
-        let history = contents.history.clone();
-        tokio::task::spawn_blocking(move || -> Result<(), GgapError> {
-            let mut batch = store.db.batch();
-            for (user_key, entry) in &data {
-                batch.insert(
-                    &store.data,
-                    data_key(new_shard_id, user_key),
-                    encode(entry)?,
-                );
-                if let Some(expires_at_ns) = entry.expires_at_ns {
-                    batch.insert(
-                        &store.ttl_index,
-                        ttl_index_key(new_shard_id, expires_at_ns, user_key),
-                        Vec::new(),
-                    );
-                }
-            }
-            for ((user_key, version), entry) in &history {
-                batch.insert(
-                    &store.history,
-                    history_key(new_shard_id, user_key, *version),
-                    encode(entry)?,
-                );
-            }
-            batch.commit().map_err(fjall_err)
+        let contents = contents.clone();
+        tokio::task::spawn_blocking(move || {
+            install_partial_snapshot_sync(&store, new_shard_id, &contents)
         })
         .await
         .map_err(|e| GgapError::Storage(e.to_string()))?
     }
 
-    /// Delete all keys `>= from_key` from a shard's data, history, and
-    /// ttl_index partitions. Used after a split to remove the upper half
-    /// from the source shard.
+    /// Delete all keys `>= from_key` from source shard.
     pub async fn delete_range_from(
         &self,
         shard_id: ShardId,
@@ -953,71 +1138,9 @@ impl FjallStateMachine {
     ) -> Result<(), GgapError> {
         let store = self.store.clone();
         let from_key = from_key.to_string();
-        tokio::task::spawn_blocking(move || -> Result<(), GgapError> {
-            let start = data_key(shard_id, &from_key);
-            let shard_end = data_shard_end(shard_id).to_vec();
-
-            // Collect data keys to delete
-            let data_keys: Vec<Vec<u8>> = store
-                .data
-                .range(start..shard_end.clone())
-                .map(|g| g.into_inner().map(|(k, _)| k.to_vec()).map_err(fjall_err))
-                .collect::<Result<_, _>>()?;
-
-            // Collect history keys to delete (filter by user key)
-            let shard_start = shard_id.to_be_bytes().to_vec();
-            let history_keys: Vec<Vec<u8>> = store
-                .history
-                .range(shard_start.clone()..shard_end.clone())
-                .filter_map(|g| match g.into_inner().map_err(fjall_err) {
-                    Ok((k, _)) => {
-                        let raw = &k[8..];
-                        if let Some(null_pos) = raw.iter().position(|&b| b == 0) {
-                            let user_key_bytes = &raw[..null_pos];
-                            if user_key_bytes >= from_key.as_bytes() {
-                                return Some(Ok(k.to_vec()));
-                            }
-                        }
-                        None
-                    }
-                    Err(e) => Some(Err(e)),
-                })
-                .collect::<Result<_, _>>()?;
-
-            // Collect TTL index keys to delete (filter by user key)
-            let ttl_keys: Vec<Vec<u8>> = store
-                .ttl_index
-                .range(shard_start..shard_end)
-                .filter_map(|g| {
-                    match g.into_inner().map_err(fjall_err) {
-                        Ok((k, _)) => {
-                            // TTL key: shard(8) ++ expires_at_ns(8) ++ key_utf8
-                            let user_key_bytes = &k[16..];
-                            if user_key_bytes >= from_key.as_bytes() {
-                                Some(Ok(k.to_vec()))
-                            } else {
-                                None
-                            }
-                        }
-                        Err(e) => Some(Err(e)),
-                    }
-                })
-                .collect::<Result<_, _>>()?;
-
-            let mut batch = store.db.batch();
-            for k in data_keys {
-                batch.remove(&store.data, k);
-            }
-            for k in history_keys {
-                batch.remove(&store.history, k);
-            }
-            for k in ttl_keys {
-                batch.remove(&store.ttl_index, k);
-            }
-            batch.commit().map_err(fjall_err)
-        })
-        .await
-        .map_err(|e| GgapError::Storage(e.to_string()))?
+        tokio::task::spawn_blocking(move || delete_range_from_sync(&store, shard_id, &from_key))
+            .await
+            .map_err(|e| GgapError::Storage(e.to_string()))?
     }
 }
 

--- a/crates/ggap-storage/src/fjall.rs
+++ b/crates/ggap-storage/src/fjall.rs
@@ -318,6 +318,11 @@ pub struct FjallStateMachine {
     watch_tx: Option<tokio::sync::broadcast::Sender<DomainWatchEvent>>,
     split_tx: Option<tokio::sync::mpsc::UnboundedSender<SplitApplied>>,
     shard_map: Option<Arc<ShardMap>>,
+    /// Fault injection: when `true`, `apply()` returns `Err` after Phase 1 commits
+    /// but before Phase 2 (ShardMap updates), simulating a crash at that boundary.
+    /// Always present but can only be armed via `arm_crash_after_phase1` which is
+    /// gated behind `#[cfg(any(test, feature = "test-utils"))]`.
+    crash_after_phase1: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl FjallStateMachine {
@@ -329,6 +334,7 @@ impl FjallStateMachine {
             watch_tx: None,
             split_tx: None,
             shard_map: None,
+            crash_after_phase1: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -340,7 +346,16 @@ impl FjallStateMachine {
             watch_tx: None,
             split_tx: None,
             shard_map: None,
+            crash_after_phase1: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
+    }
+
+    /// Arm the crash-injection point between Phase 1 and Phase 2 of a Split apply.
+    /// Available in test builds and when the `test-utils` feature is enabled.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn arm_crash_after_phase1(&self) {
+        self.crash_after_phase1
+            .store(true, std::sync::atomic::Ordering::SeqCst);
     }
 
     pub fn with_clock(mut self, now_fn: NowFn) -> Self {
@@ -437,6 +452,17 @@ impl StateMachineStore for FjallStateMachine {
             })
             .await
             .map_err(|e| GgapError::Storage(e.to_string()))??;
+
+            // Fault injection: simulate a crash after Phase 1 commits but before Phase 2.
+            // The flag is never armed in production (arm_crash_after_phase1 is test-only).
+            if self
+                .crash_after_phase1
+                .load(std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(GgapError::Storage(
+                    "simulated crash after phase 1".into(),
+                ));
+            }
 
             // Phase 2: update ShardMap in-memory cache (async).
             if let Some(ref sm) = self.shard_map {

--- a/crates/ggap-storage/src/lib.rs
+++ b/crates/ggap-storage/src/lib.rs
@@ -6,6 +6,7 @@ pub mod traits;
 pub mod ttl;
 pub mod types;
 
+pub use fjall::SplitApplied;
 pub use shard_map::ShardMap;
 pub use traits::{LogStorage, StateMachineStore};
 pub use types::{LogEntry, LogPayload, LogState, Snapshot, SnapshotContents, SnapshotMeta, Vote};

--- a/crates/ggap-storage/src/mem.rs
+++ b/crates/ggap-storage/src/mem.rs
@@ -313,6 +313,12 @@ impl StateMachineStore for MemStateMachine {
                 // Raft-internal entry (Blank, Membership). No state change; return NoOp.
                 KvResponse::NoOp
             }
+            Some(KvCommand::Split { .. }) => {
+                // MemStateMachine is used only in tests; Split is not supported there.
+                return Err(GgapError::InvalidArgument(
+                    "Split command not supported by MemStateMachine".into(),
+                ));
+            }
         };
 
         if let Some(bytes) = membership_bytes {

--- a/crates/ggap-storage/src/shard_map.rs
+++ b/crates/ggap-storage/src/shard_map.rs
@@ -140,11 +140,7 @@ impl ShardMap {
     /// Update only the in-memory cache for two shards after a split whose
     /// storage writes have already been committed atomically by the caller.
     /// Does NOT write to fjall — storage is already consistent.
-    pub async fn update_cache_after_split(
-        &self,
-        updated_source: ShardInfo,
-        new_shard: ShardInfo,
-    ) {
+    pub async fn update_cache_after_split(&self, updated_source: ShardInfo, new_shard: ShardInfo) {
         let mut shards = self.shards.write().await;
         shards.insert(updated_source.shard_id, updated_source);
         shards.insert(new_shard.shard_id, new_shard);

--- a/crates/ggap-storage/src/shard_map.rs
+++ b/crates/ggap-storage/src/shard_map.rs
@@ -12,13 +12,19 @@ use crate::keys::meta_key;
 /// keyspace. This must never collide with a real shard_id.
 const SHARD_MAP_PREFIX: ShardId = u64::MAX;
 
-fn shard_map_key(shard_id: ShardId) -> Vec<u8> {
+pub(crate) fn shard_map_key(shard_id: ShardId) -> Vec<u8> {
     // meta_key(SHARD_MAP_PREFIX, "shard:XXXX") where XXXX is be_u64(shard_id)
     let label = format!("shard:{}", shard_id);
     meta_key(SHARD_MAP_PREFIX, &label)
 }
 
-fn encode<T: serde::Serialize>(val: &T) -> Result<Vec<u8>, GgapError> {
+/// Key used to store bootstrap membership for a shard created by a split.
+/// Written atomically with the split data movement so restart can find peers.
+pub(crate) fn bootstrap_members_key(shard_id: ShardId) -> Vec<u8> {
+    meta_key(shard_id, "bootstrap_members")
+}
+
+pub(crate) fn encode<T: serde::Serialize>(val: &T) -> Result<Vec<u8>, GgapError> {
     bincode::serde::encode_to_vec(val, bincode::config::standard())
         .map_err(|e| GgapError::Storage(e.to_string()))
 }
@@ -129,6 +135,19 @@ impl ShardMap {
     /// The caller must subsequently update the in-memory cache via `put_shard`.
     pub fn put_shard_sync(&self, info: &ShardInfo) -> Result<(), GgapError> {
         self.persist_shard(info)
+    }
+
+    /// Update only the in-memory cache for two shards after a split whose
+    /// storage writes have already been committed atomically by the caller.
+    /// Does NOT write to fjall — storage is already consistent.
+    pub async fn update_cache_after_split(
+        &self,
+        updated_source: ShardInfo,
+        new_shard: ShardInfo,
+    ) {
+        let mut shards = self.shards.write().await;
+        shards.insert(updated_source.shard_id, updated_source);
+        shards.insert(new_shard.shard_id, new_shard);
     }
 }
 

--- a/crates/ggap-storage/src/shard_map.rs
+++ b/crates/ggap-storage/src/shard_map.rs
@@ -123,6 +123,13 @@ impl ShardMap {
             .insert(key, val)
             .map_err(|e| GgapError::Storage(e.to_string()))
     }
+
+    /// Synchronous variant of `put_shard` — writes only to fjall storage,
+    /// not to the in-memory cache. Safe to call from `spawn_blocking` contexts.
+    /// The caller must subsequently update the in-memory cache via `put_shard`.
+    pub fn put_shard_sync(&self, info: &ShardInfo) -> Result<(), GgapError> {
+        self.persist_shard(info)
+    }
 }
 
 #[cfg(test)]

--- a/crates/ggap-storage/src/types.rs
+++ b/crates/ggap-storage/src/types.rs
@@ -56,7 +56,7 @@ pub struct SnapshotMeta {
 /// partition are captured so that `at_version` reads survive a snapshot
 /// round-trip on the node that built it, and remain available on a follower
 /// that receives and installs the snapshot.
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnapshotContents {
     /// Current value per key (mirrors the `data` partition).
     pub data: Vec<(String, KvEntry)>,

--- a/crates/ggap-storage/tests/split_crash_bugs.rs
+++ b/crates/ggap-storage/tests/split_crash_bugs.rs
@@ -1,0 +1,237 @@
+/// Regression tests that demonstrate the two crash-safety bugs in the shard
+/// split implementation.
+///
+/// Both tests must **fail** (assert the buggy state) until the atomic-commit
+/// fix is applied. After the fix they are updated to assert the correct state.
+///
+/// # Why `#[cfg(test)]` fault injection instead of the DST framework
+///
+/// The existing `sim_cluster` DST simulates crashes via `raft.shutdown()`, which
+/// is a *graceful* shutdown that allows in-flight `apply()` calls to complete.
+/// There is no way to interrupt a `spawn_blocking` thread mid-execution from
+/// outside the thread, so the DST cannot land a kill signal between Phase 1's
+/// `batch.commit()` and Phase 2's ShardMap writes — those two steps execute in
+/// the same async task with no intervening yield that a shutdown signal would
+/// win. The `arm_crash_after_phase1()` injection point is the standard Rust
+/// technique for this class of test (used by TiKV, CockroachDB, etc.).
+use std::sync::Arc;
+
+use ggap_storage::fjall::{FjallStateMachine, FjallStore};
+use ggap_storage::keys::{data_key, meta_key};
+use ggap_storage::{ShardMap, StateMachineStore};
+use ggap_types::{KeyRange, KvCommand, KvResponse, LogId};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn log_id(index: u64) -> LogId {
+    LogId {
+        term: 1,
+        leader_id: 1,
+        index,
+    }
+}
+
+async fn apply_put(fsm: &FjallStateMachine, shard_id: u64, index: u64, key: &str, val: &str) {
+    fsm.apply(
+        shard_id,
+        log_id(index),
+        Some(KvCommand::Put {
+            key: key.to_string(),
+            value: val.as_bytes().to_vec(),
+            ttl_ns: None,
+            expect_version: 0,
+        }),
+        None,
+    )
+    .await
+    .unwrap();
+}
+
+fn has_key(store: &FjallStore, shard_id: u64, key: &str) -> bool {
+    store
+        .data
+        .get(data_key(shard_id, key))
+        .unwrap()
+        .is_some()
+}
+
+fn last_applied_index(store: &FjallStore, shard_id: u64) -> Option<u64> {
+    let raw = store.meta.get(meta_key(shard_id, "last_applied")).unwrap()?;
+    let (log_id, _): (LogId, _) =
+        bincode::serde::decode_from_slice(&raw, bincode::config::standard()).unwrap();
+    Some(log_id.index)
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1: non-atomic split loses data on crash between Phase 1 and Phase 2
+// ---------------------------------------------------------------------------
+
+/// Demonstrates that a crash between Phase 1 (data movement committed to disk)
+/// and Phase 2 (ShardMap persisted) leaves the store in an unrecoverable
+/// inconsistent state:
+///
+/// - Data for the upper half is deleted from shard 0 (Phase 1 ran)
+/// - ShardMap still shows shard 0 owning the full range (Phase 2 never ran)
+/// - `last_applied` is advanced past the split entry, so Raft won't re-apply it
+/// - The upper-half data exists in shard 1's storage but is unroutable
+#[tokio::test]
+async fn bug1_nonatomic_split_loses_data_on_crash() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // --- Setup: write some data then apply a split with crash injection ---
+    {
+        let store = FjallStore::open(dir.path()).unwrap();
+        let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
+        shard_map.initialize_default().await.unwrap();
+        let (split_tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut fsm = FjallStateMachine::new(store.clone());
+        fsm.set_split_sender(split_tx);
+        fsm.set_shard_map(shard_map.clone());
+
+        apply_put(&fsm, 0, 1, "apple", "v1").await;
+        apply_put(&fsm, 0, 2, "banana", "v2").await;
+        apply_put(&fsm, 0, 3, "mango", "v3").await;
+        apply_put(&fsm, 0, 4, "zebra", "v4").await;
+
+        // Arm the fault injection: apply() will return Err after Phase 1
+        // commits but before Phase 2 writes the ShardMap.
+        fsm.arm_crash_after_phase1();
+
+        let result = fsm
+            .apply(
+                0,
+                log_id(5),
+                Some(KvCommand::Split {
+                    split_key: "m".into(),
+                    new_shard_id: 1,
+                    source_range: KeyRange {
+                        start: String::new(),
+                        end: String::new(),
+                    },
+                }),
+                None,
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "expected simulated crash error, got: {:?}",
+            result
+        );
+        // FSM is dropped here, simulating process death after Phase 1.
+    }
+
+    // --- Restart: reopen store from the same path ---
+    let store2 = FjallStore::open(dir.path()).unwrap();
+    let shard_map2 = ShardMap::load(store2.clone()).unwrap();
+
+    // BUG: ShardMap shows only shard 0 with the full range.
+    // Shard 1 was never written in Phase 2.
+    let shards = shard_map2.all_shards().await;
+    assert_eq!(
+        shards.len(),
+        1,
+        "bug1: ShardMap should have 2 shards after split, but has {}",
+        shards.len()
+    );
+    assert!(
+        shards[0].range.end.is_empty(),
+        "bug1: shard 0 still claims the full key range"
+    );
+
+    // BUG: upper-half data is gone from shard 0 (Phase 1 deleted it)
+    assert!(
+        has_key(&store2, 0, "apple"),
+        "lower-half key 'apple' should still be in shard 0"
+    );
+    assert!(
+        !has_key(&store2, 0, "mango"),
+        "bug1: 'mango' was deleted from shard 0 by Phase 1 but ShardMap still claims shard 0 owns it"
+    );
+
+    // BUG: data exists in shard 1 storage but is unroutable via ShardMap
+    assert!(
+        has_key(&store2, 1, "mango"),
+        "bug1: 'mango' is stranded in shard 1 storage with no ShardMap entry routing to it"
+    );
+
+    // BUG: last_applied is advanced past the split entry; Raft won't re-apply it
+    assert_eq!(
+        last_applied_index(&store2, 0),
+        Some(5),
+        "bug1: last_applied must equal split entry index so Raft skips re-apply"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2: no bootstrap_members stored for the new shard
+// ---------------------------------------------------------------------------
+
+/// Demonstrates that after a complete split (all phases), no membership info
+/// is persisted for the new shard. On restart, `main.rs` falls back to
+/// single-node initialisation for the new shard, silently discarding the
+/// 3-node replication that the original cluster had.
+#[tokio::test]
+async fn bug2_no_bootstrap_members_for_split_shard() {
+    let dir = tempfile::tempdir().unwrap();
+
+    {
+        let store = FjallStore::open(dir.path()).unwrap();
+        let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
+        shard_map.initialize_default().await.unwrap();
+        let (split_tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut fsm = FjallStateMachine::new(store.clone());
+        fsm.set_split_sender(split_tx);
+        fsm.set_shard_map(shard_map.clone());
+
+        apply_put(&fsm, 0, 1, "apple", "v1").await;
+        apply_put(&fsm, 0, 2, "mango", "v2").await;
+
+        // Full split — no crash injection, all phases complete.
+        let resp = fsm
+            .apply(
+                0,
+                log_id(3),
+                Some(KvCommand::Split {
+                    split_key: "m".into(),
+                    new_shard_id: 1,
+                    source_range: KeyRange {
+                        start: String::new(),
+                        end: String::new(),
+                    },
+                }),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(resp, KvResponse::SplitComplete { new_shard_id: 1 }),
+            "expected SplitComplete, got {:?}",
+            resp
+        );
+    }
+
+    // --- Restart ---
+    let store2 = FjallStore::open(dir.path()).unwrap();
+    let shard_map2 = ShardMap::load(store2.clone()).unwrap();
+
+    // Split completed: both shards should be in the ShardMap.
+    assert_eq!(
+        shard_map2.all_shards().await.len(),
+        2,
+        "split completed, ShardMap must show 2 shards"
+    );
+
+    // BUG: no bootstrap_members key stored for shard 1.
+    // On restart, main.rs has no way to know the membership for shard 1
+    // and falls back to single-node initialization.
+    let bootstrap_key = meta_key(1, "bootstrap_members");
+    let result = store2.meta.get(&bootstrap_key).unwrap();
+    assert!(
+        result.is_none(),
+        "bug2: bootstrap_members must be absent — this is the bug being demonstrated"
+    );
+}

--- a/crates/ggap-storage/tests/split_crash_bugs.rs
+++ b/crates/ggap-storage/tests/split_crash_bugs.rs
@@ -50,15 +50,14 @@ async fn apply_put(fsm: &FjallStateMachine, shard_id: u64, index: u64, key: &str
 }
 
 fn has_key(store: &FjallStore, shard_id: u64, key: &str) -> bool {
-    store
-        .data
-        .get(data_key(shard_id, key))
-        .unwrap()
-        .is_some()
+    store.data.get(data_key(shard_id, key)).unwrap().is_some()
 }
 
 fn last_applied_index(store: &FjallStore, shard_id: u64) -> Option<u64> {
-    let raw = store.meta.get(meta_key(shard_id, "last_applied")).unwrap()?;
+    let raw = store
+        .meta
+        .get(meta_key(shard_id, "last_applied"))
+        .unwrap()?;
     let (log_id, _): (LogId, _) =
         bincode::serde::decode_from_slice(&raw, bincode::config::standard()).unwrap();
     Some(log_id.index)
@@ -133,11 +132,21 @@ async fn bug1_nonatomic_split_loses_data_on_crash() {
 
     // Both shards are in the ShardMap — written atomically with the data.
     let shards = shard_map2.all_shards().await;
-    assert_eq!(shards.len(), 2, "both shards must be in the ShardMap after atomic commit");
+    assert_eq!(
+        shards.len(),
+        2,
+        "both shards must be in the ShardMap after atomic commit"
+    );
 
     // Lower-half data still in shard 0.
-    assert!(has_key(&store2, 0, "apple"), "'apple' must remain in shard 0");
-    assert!(!has_key(&store2, 0, "mango"), "'mango' must have been moved out of shard 0");
+    assert!(
+        has_key(&store2, 0, "apple"),
+        "'apple' must remain in shard 0"
+    );
+    assert!(
+        !has_key(&store2, 0, "mango"),
+        "'mango' must have been moved out of shard 0"
+    );
 
     // Upper-half data routable via shard 1.
     assert!(has_key(&store2, 1, "mango"), "'mango' must be in shard 1");
@@ -221,5 +230,8 @@ async fn bug2_no_bootstrap_members_for_split_shard() {
     let raw = result.unwrap();
     let (members, _): (std::collections::BTreeMap<u64, String>, _) =
         bincode::serde::decode_from_slice(&raw, bincode::config::standard()).unwrap();
-    assert_eq!(members.get(&1u64).map(|s| s.as_str()), Some("127.0.0.1:7001"));
+    assert_eq!(
+        members.get(&1u64).map(|s| s.as_str()),
+        Some("127.0.0.1:7001")
+    );
 }

--- a/crates/ggap-storage/tests/split_crash_bugs.rs
+++ b/crates/ggap-storage/tests/split_crash_bugs.rs
@@ -110,6 +110,7 @@ async fn bug1_nonatomic_split_loses_data_on_crash() {
                         start: String::new(),
                         end: String::new(),
                     },
+                    source_members: [(1u64, "127.0.0.1:7001".to_string())].into(),
                 }),
                 None,
             )
@@ -124,45 +125,25 @@ async fn bug1_nonatomic_split_loses_data_on_crash() {
     }
 
     // --- Restart: reopen store from the same path ---
+    // The fault injection fired after the atomic batch committed, so storage
+    // is fully consistent: ShardMap, data, and last_applied were all written
+    // in the same batch.commit() call.
     let store2 = FjallStore::open(dir.path()).unwrap();
     let shard_map2 = ShardMap::load(store2.clone()).unwrap();
 
-    // BUG: ShardMap shows only shard 0 with the full range.
-    // Shard 1 was never written in Phase 2.
+    // Both shards are in the ShardMap — written atomically with the data.
     let shards = shard_map2.all_shards().await;
-    assert_eq!(
-        shards.len(),
-        1,
-        "bug1: ShardMap should have 2 shards after split, but has {}",
-        shards.len()
-    );
-    assert!(
-        shards[0].range.end.is_empty(),
-        "bug1: shard 0 still claims the full key range"
-    );
+    assert_eq!(shards.len(), 2, "both shards must be in the ShardMap after atomic commit");
 
-    // BUG: upper-half data is gone from shard 0 (Phase 1 deleted it)
-    assert!(
-        has_key(&store2, 0, "apple"),
-        "lower-half key 'apple' should still be in shard 0"
-    );
-    assert!(
-        !has_key(&store2, 0, "mango"),
-        "bug1: 'mango' was deleted from shard 0 by Phase 1 but ShardMap still claims shard 0 owns it"
-    );
+    // Lower-half data still in shard 0.
+    assert!(has_key(&store2, 0, "apple"), "'apple' must remain in shard 0");
+    assert!(!has_key(&store2, 0, "mango"), "'mango' must have been moved out of shard 0");
 
-    // BUG: data exists in shard 1 storage but is unroutable via ShardMap
-    assert!(
-        has_key(&store2, 1, "mango"),
-        "bug1: 'mango' is stranded in shard 1 storage with no ShardMap entry routing to it"
-    );
+    // Upper-half data routable via shard 1.
+    assert!(has_key(&store2, 1, "mango"), "'mango' must be in shard 1");
 
-    // BUG: last_applied is advanced past the split entry; Raft won't re-apply it
-    assert_eq!(
-        last_applied_index(&store2, 0),
-        Some(5),
-        "bug1: last_applied must equal split entry index so Raft skips re-apply"
-    );
+    // last_applied advanced, split will not be re-applied.
+    assert_eq!(last_applied_index(&store2, 0), Some(5));
 }
 
 // ---------------------------------------------------------------------------
@@ -201,6 +182,7 @@ async fn bug2_no_bootstrap_members_for_split_shard() {
                         start: String::new(),
                         end: String::new(),
                     },
+                    source_members: [(1u64, "127.0.0.1:7001".to_string())].into(),
                 }),
                 None,
             )
@@ -225,13 +207,19 @@ async fn bug2_no_bootstrap_members_for_split_shard() {
         "split completed, ShardMap must show 2 shards"
     );
 
-    // BUG: no bootstrap_members key stored for shard 1.
-    // On restart, main.rs has no way to know the membership for shard 1
-    // and falls back to single-node initialization.
+    // bootstrap_members is now written atomically with the split data.
+    // On restart, main.rs can read this key and initialise the new shard
+    // with the correct multi-node membership.
     let bootstrap_key = meta_key(1, "bootstrap_members");
     let result = store2.meta.get(&bootstrap_key).unwrap();
     assert!(
-        result.is_none(),
-        "bug2: bootstrap_members must be absent — this is the bug being demonstrated"
+        result.is_some(),
+        "bootstrap_members must be present after the fix so restart uses correct membership"
     );
+
+    // The stored membership should match what was passed in source_members.
+    let raw = result.unwrap();
+    let (members, _): (std::collections::BTreeMap<u64, String>, _) =
+        bincode::serde::decode_from_slice(&raw, bincode::config::standard()).unwrap();
+    assert_eq!(members.get(&1u64).map(|s| s.as_str()), Some("127.0.0.1:7001"));
 }

--- a/crates/ggap-types/src/lib.rs
+++ b/crates/ggap-types/src/lib.rs
@@ -89,6 +89,14 @@ pub enum KvCommand {
         new_value: Vec<u8>,
         ttl_ns: Option<i64>,
     },
+    /// Proposed by the split coordinator through the source shard's Raft log.
+    /// Every node applies this deterministically: copy keys >= split_key to
+    /// new_shard_id, delete them from source, update ShardMap ranges.
+    Split {
+        split_key: String,
+        new_shard_id: ShardId,
+        source_range: KeyRange,
+    },
 }
 
 /// Responses returned from state machine apply
@@ -113,6 +121,11 @@ pub enum KvResponse {
     /// Returned for Raft-internal entries (Blank, Membership).
     /// Never sent to clients; guarded by unreachable!() in ggap-server.
     NoOp,
+    /// Returned to the split coordinator after a KvCommand::Split is applied.
+    /// Never routed through the KV service path.
+    SplitComplete {
+        new_shard_id: ShardId,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ggap-types/src/lib.rs
+++ b/crates/ggap-types/src/lib.rs
@@ -91,11 +91,19 @@ pub enum KvCommand {
     },
     /// Proposed by the split coordinator through the source shard's Raft log.
     /// Every node applies this deterministically: copy keys >= split_key to
-    /// new_shard_id, delete them from source, update ShardMap ranges.
+    /// new_shard_id, delete them from source, update ShardMap ranges, and
+    /// persist bootstrap membership for the new shard so it can be restarted
+    /// with the correct Raft group.
     Split {
         split_key: String,
         new_shard_id: ShardId,
         source_range: KeyRange,
+        /// Raft membership for the new shard: node_id → gRPC address.
+        /// Stored atomically alongside the data movement so that on restart
+        /// main.rs can initialise the new shard with the correct peers.
+        /// Uses `String` addresses (not `BasicNode`) to keep ggap-types free
+        /// of any openraft dependency.
+        source_members: std::collections::BTreeMap<u64, String>,
     },
 }
 


### PR DESCRIPTION
GgapLogStorage bypassed the LogStorage trait and talked directly to
FjallStore keyspaces, creating a parallel implementation alongside
FjallLogStorage. This change enriches the LogStorage trait to cover all
openraft adapter needs and rewrites GgapLogStorage as a generic
adapter over S: LogStorage with zero fjall imports.

Key changes:
- LogEntry gains leader_id field; LogState uses Option<LogId>
- LogStorage trait: add save_committed/read_committed, purge takes LogId
- GgapLogStorage<S: LogStorage> replaces GgapLogStorage(Arc<FjallStore>)
- New Entry<->LogEntry, Vote, LogState conversions in convert.rs
- All spawn_blocking stays in ggap-storage where it belongs

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>