### PR TITLE
Add Kind-based local deploy with OTel Collector + Prometheus + Grafana

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+target/
+.git/
+.github/
+.claude/
+docs/
+deploy/
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.7
+
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends protobuf-compiler \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release -p ggap-node
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system --uid 10001 --home-dir /var/lib/ginnungagap --shell /usr/sbin/nologin ggap \
+ && mkdir -p /var/lib/ginnungagap /etc/ginnungagap \
+ && chown -R ggap:ggap /var/lib/ginnungagap /etc/ginnungagap
+
+COPY --from=builder /app/target/release/ggap-node /usr/local/bin/ggap-node
+COPY config/ /etc/ginnungagap/
+
+USER ggap
+WORKDIR /var/lib/ginnungagap
+EXPOSE 17000 17001 9090
+ENTRYPOINT ["/usr/local/bin/ggap-node"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+CLUSTER ?= ggap
+IMAGE   ?= ginnungagap:dev
+NS      ?= ginnungagap
+
+.PHONY: help kind-up build deploy wait grafana status logs down up reset
+
+help:
+	@echo "Ginnungagap local Kind cluster targets:"
+	@echo "  make up          - full end-to-end: create kind, build image, deploy, wait"
+	@echo "  make kind-up     - create the kind cluster only"
+	@echo "  make build       - docker build + kind load docker-image"
+	@echo "  make deploy      - kubectl apply -k deploy/k8s"
+	@echo "  make wait        - wait for ggap / otel / grafana rollouts"
+	@echo "  make grafana     - print Grafana URL (NodePort mapped to localhost:3000)"
+	@echo "  make status      - show pods"
+	@echo "  make logs        - follow ggap-0 logs"
+	@echo "  make reset       - delete and recreate the StatefulSet's PVCs and pods"
+	@echo "  make down        - delete the kind cluster"
+
+kind-up:
+	kind create cluster --config deploy/kind/kind-config.yaml --name $(CLUSTER)
+
+build:
+	docker build -t $(IMAGE) .
+	kind load docker-image $(IMAGE) --name $(CLUSTER)
+
+deploy:
+	kubectl apply -k deploy/k8s/
+
+wait:
+	kubectl -n $(NS) rollout status statefulset/ggap --timeout=300s
+	kubectl -n $(NS) rollout status deploy/otel-collector --timeout=180s
+	kubectl -n $(NS) rollout status deploy/prometheus --timeout=180s
+	kubectl -n $(NS) rollout status deploy/grafana --timeout=180s
+
+grafana:
+	@echo "Grafana:    http://localhost:3000  (admin / admin)"
+	@echo "ggap gRPC:  localhost:17000        (client NodePort)"
+
+status:
+	@kubectl -n $(NS) get pods -o wide
+
+logs:
+	kubectl -n $(NS) logs -f ggap-0
+
+reset:
+	kubectl -n $(NS) delete statefulset ggap --ignore-not-found
+	kubectl -n $(NS) delete pvc -l app.kubernetes.io/name=ggap-node --ignore-not-found
+	kubectl apply -k deploy/k8s/
+
+up: kind-up build deploy wait grafana
+
+down:
+	kind delete cluster --name $(CLUSTER)

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,16 @@ CLUSTER ?= ggap
 IMAGE   ?= ginnungagap:dev
 NS      ?= ginnungagap
 
-.PHONY: help kind-up build deploy wait grafana status logs down up reset
+.PHONY: help kind-up build deploy wait bootstrap grafana status logs down up reset
 
 help:
 	@echo "Ginnungagap local Kind cluster targets:"
-	@echo "  make up          - full end-to-end: create kind, build image, deploy, wait"
+	@echo "  make up          - full end-to-end: kind, build, deploy, wait, bootstrap"
 	@echo "  make kind-up     - create the kind cluster only"
 	@echo "  make build       - docker build + kind load docker-image"
 	@echo "  make deploy      - kubectl apply -k deploy/k8s"
-	@echo "  make wait        - wait for ggap / otel / grafana rollouts"
+	@echo "  make wait        - wait for ggap / otel / prometheus / grafana rollouts"
+	@echo "  make bootstrap   - run the Job that forms the 3-voter Raft cluster"
 	@echo "  make grafana     - print Grafana URL (NodePort mapped to localhost:3000)"
 	@echo "  make status      - show pods"
 	@echo "  make logs        - follow ggap-0 logs"
@@ -33,6 +34,16 @@ wait:
 	kubectl -n $(NS) rollout status deploy/prometheus --timeout=180s
 	kubectl -n $(NS) rollout status deploy/grafana --timeout=180s
 
+# Applied separately from the root kustomization: Job pod templates are
+# immutable, so keeping it out of `kubectl apply -k` lets re-apply stay
+# idempotent. The Job itself is idempotent (exits 0 if 3 voters already).
+bootstrap:
+	kubectl -n $(NS) delete job ggap-bootstrap --ignore-not-found
+	kubectl apply -f deploy/k8s/bootstrap/job.yaml
+	kubectl -n $(NS) wait --for=condition=complete --timeout=120s job/ggap-bootstrap
+	@echo "--- bootstrap Job logs ---"
+	@kubectl -n $(NS) logs job/ggap-bootstrap
+
 grafana:
 	@echo "Grafana:    http://localhost:3000  (admin / admin)"
 	@echo "ggap gRPC:  localhost:17000        (client NodePort)"
@@ -44,11 +55,12 @@ logs:
 	kubectl -n $(NS) logs -f ggap-0
 
 reset:
+	kubectl -n $(NS) delete job ggap-bootstrap --ignore-not-found
 	kubectl -n $(NS) delete statefulset ggap --ignore-not-found
 	kubectl -n $(NS) delete pvc -l app.kubernetes.io/name=ggap-node --ignore-not-found
 	kubectl apply -k deploy/k8s/
 
-up: kind-up build deploy wait grafana
+up: kind-up build deploy wait bootstrap grafana
 
 down:
 	kind delete cluster --name $(CLUSTER)

--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -40,6 +40,12 @@ struct Cli {
     /// Peer specs: "id=addr" format, repeatable
     #[arg(long = "peer")]
     peers: Vec<String>,
+    /// Initialize shard 0 as a fresh single-voter Raft cluster on first boot.
+    /// Exactly one node in a fresh deployment should run with this flag; other
+    /// nodes start uninitialized and wait for `AdminService.AddLearner` +
+    /// `AdminService.ChangeMembership` from the seed.
+    #[arg(long)]
+    seed: bool,
     #[arg(long)]
     config: Option<std::path::PathBuf>,
     #[arg(long, default_value = "/var/lib/ginnungagap")]
@@ -230,47 +236,63 @@ async fn main() -> anyhow::Result<()> {
                 .with_context(|| format!("failed to create Raft for shard {shard_id}"))?,
         );
 
-        // Initialize Raft membership on first boot.
-        // - Shard 0 (and any shard created before this fix): single-node bootstrap.
-        // - Split-created shards: read membership from bootstrap_members key written
-        //   atomically with the split data movement. This prevents a restarted node
-        //   from re-initializing as a single-node cluster, discarding replication.
+        // Initialize Raft membership on first boot. Three cases:
+        //   1. `bootstrap_members` meta key present — split-created shard. Always
+        //      initialize from the persisted membership (written atomically with
+        //      the split data movement; a restart must not re-init as single-node).
+        //   2. No `bootstrap_members` and `--seed` was passed — fresh seed node.
+        //      Initialize shard 0 as a single-voter cluster; other nodes join
+        //      later via AdminService.AddLearner/ChangeMembership.
+        //   3. No `bootstrap_members` and no `--seed` — non-seed fresh node.
+        //      Leave Raft uninitialized; it will pick up membership when the
+        //      seed sends it AppendEntries after AddLearner.
         if !raft
             .is_initialized()
             .await
             .with_context(|| format!("raft.is_initialized failed for shard {shard_id}"))?
         {
             let bootstrap_key = meta_key(shard_id, "bootstrap_members");
-            let members: BTreeMap<u64, BasicNode> = match store.meta.get(&bootstrap_key) {
+            let members: Option<BTreeMap<u64, BasicNode>> = match store.meta.get(&bootstrap_key) {
                 Ok(Some(bytes)) => {
                     let (addr_map, _): (BTreeMap<u64, String>, _) =
                         bincode::serde::decode_from_slice(&bytes, bincode::config::standard())
                             .with_context(|| {
                                 format!("failed to decode bootstrap_members for shard {shard_id}")
                             })?;
-                    addr_map
-                        .into_iter()
-                        .map(|(id, addr)| (id, BasicNode { addr }))
-                        .collect()
+                    Some(
+                        addr_map
+                            .into_iter()
+                            .map(|(id, addr)| (id, BasicNode { addr }))
+                            .collect(),
+                    )
                 }
-                Ok(None) => {
-                    // Original shard or pre-fix split: fall back to single-node init.
-                    BTreeMap::from([(
-                        cli.node_id,
-                        BasicNode {
-                            addr: cluster_addr.to_string(),
-                        },
-                    )])
-                }
+                Ok(None) if cli.seed => Some(BTreeMap::from([(
+                    cli.node_id,
+                    BasicNode {
+                        addr: cluster_addr.to_string(),
+                    },
+                )])),
+                Ok(None) => None,
                 Err(e) => {
                     return Err(anyhow::anyhow!(
                         "failed to read bootstrap_members for shard {shard_id}: {e}"
                     ));
                 }
             };
-            raft.initialize(members)
-                .await
-                .map_err(|e| anyhow::anyhow!("raft.initialize failed for shard {shard_id}: {e}"))?;
+            match members {
+                Some(members) => {
+                    raft.initialize(members).await.map_err(|e| {
+                        anyhow::anyhow!("raft.initialize failed for shard {shard_id}: {e}")
+                    })?;
+                }
+                None => {
+                    tracing::info!(
+                        shard_id,
+                        node_id = cli.node_id,
+                        "non-seed fresh node: Raft uninitialized, waiting for AddLearner"
+                    );
+                }
+            }
         }
 
         let node = Arc::new(OpenRaftNode::new(

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,8 +1,8 @@
 # Ginnungagap on Kind
 
-Local observability harness: three Ginnungagap pods, an OpenTelemetry
-Collector scraping their Prometheus metrics, a minimal Prometheus for PromQL,
-and Grafana with a provisioned dashboard.
+Local 3-node Ginnungagap cluster with an OpenTelemetry Collector scraping
+Prometheus metrics from every pod, a minimal Prometheus for PromQL, and
+Grafana with a provisioned dashboard.
 
 ## Prerequisites
 
@@ -23,6 +23,7 @@ That runs:
 2. `make build` — build the `ggap-node` image and `kind load` it
 3. `make deploy` — `kubectl apply -k deploy/k8s`
 4. `make wait` — wait for ggap / OTel / Prometheus / Grafana rollouts
+5. `make bootstrap` — run a Job that forms the 3-voter Raft cluster on shard 0
 
 After it completes:
 
@@ -72,27 +73,33 @@ grpcurl -plaintext -d '{"key":"aGVsbG8="}' \
 The Grafana dashboard should show `ggap_kv_requests_total` climbing within
 ~30 seconds (OTel scrape + Prometheus scrape intervals stacked).
 
-## Known limitation: cluster formation
+## How cluster formation works
 
-`ggap-node` today single-node-bootstraps a Raft group on any fresh data dir
-(`crates/ggap-node/src/main.rs:238-274`). Because all three pods start from
-empty PVCs and there is no CLI surface to skip that bootstrap, **this deploy
-runs three independent single-node Raft clusters, not one 3-voter quorum**.
+`ggap-node` normally self-bootstraps a fresh data dir as a single-voter
+cluster. With three pods starting simultaneously that would produce three
+separate clusters, so a `--seed` flag gates that behavior: only `ggap-0`
+(ordinal 0) runs with `--seed`. `ggap-1` and `ggap-2` start uninitialized —
+openraft instances that will accept `AppendEntries` but do nothing on their
+own.
 
-The observability pipeline still works as intended — OTel discovers and scrapes
-all three pods, Grafana fans them in side-by-side — and each pod's
-`KvService` is usable on its own.
+The `ggap-bootstrap` Job (run by `make bootstrap`) then calls AdminService
+on `ggap-0.ggap-headless.ginnungagap.svc:17001`:
 
-To exercise true Raft quorum on this harness, scale down to a real single
-node:
+1. `AddLearner` for node_id 2 (ggap-1) and node_id 3 (ggap-2)
+2. `ChangeMembership([1, 2, 3])` to promote the learners to voters
+
+The Job is idempotent: if `ClusterStatus` already reports 3 voters it exits 0.
+It is kept out of the root `kubectl apply -k` target because Job pod templates
+are immutable, which would break re-apply.
+
+To inspect the Raft state from inside the cluster:
 
 ```
-kubectl -n ginnungagap scale sts/ggap --replicas=1
+kubectl -n ginnungagap run --rm -it grpcurl \
+  --image=fullstorydev/grpcurl:v1.9.1-alpine --restart=Never -- \
+  -plaintext ggap-0.ggap-headless.ginnungagap.svc:17001 \
+  ginnungagap.v1.AdminService/ClusterStatus
 ```
-
-Forming an actual 3-voter quorum needs a future `--initial-members` or
-`--seed` flag on `ggap-node` plus either a bootstrap Job or a pre-written
-`bootstrap_members` meta key. That work is tracked for a later pass.
 
 ## Caveats
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,104 @@
+# Ginnungagap on Kind
+
+Local observability harness: three Ginnungagap pods, an OpenTelemetry
+Collector scraping their Prometheus metrics, a minimal Prometheus for PromQL,
+and Grafana with a provisioned dashboard.
+
+## Prerequisites
+
+- Docker
+- `kind` (tested with v0.23+)
+- `kubectl`
+- `grpcurl` (only needed for the verification commands below)
+
+## One-shot bring-up
+
+```
+make up
+```
+
+That runs:
+
+1. `make kind-up` — create a 1 control-plane + 3 worker Kind cluster named `ggap`
+2. `make build` — build the `ggap-node` image and `kind load` it
+3. `make deploy` — `kubectl apply -k deploy/k8s`
+4. `make wait` — wait for ggap / OTel / Prometheus / Grafana rollouts
+
+After it completes:
+
+- Grafana: <http://localhost:3000> (admin / admin). Folder **Ginnungagap**
+  holds the provisioned **Ginnungagap — Overview** dashboard.
+- ggap client gRPC on `localhost:17000` (NodePort 30700 on the control-plane
+  node, mapped to host port 17000 via Kind `extraPortMappings`).
+
+## Pipeline
+
+```
+ggap-{0,1,2}           :9090/   (Prometheus text, served at path "/")
+      |
+      v
+OTel Collector         (prometheus receiver + kubernetes_sd pod discovery)
+      |
+      |  prometheus exporter on :8889
+      v
+Prometheus             (emptyDir, 1h retention)
+      |
+      v
+Grafana                (provisioned Prometheus datasource + dashboard)
+```
+
+The metrics endpoint on `ggap-node` is `/`, not `/metrics` —
+`deploy/k8s/otel/configmap.yaml` sets `metrics_path: /` accordingly.
+
+## Useful commands
+
+```
+make status         # pods
+make logs           # follow ggap-0
+make reset          # delete StatefulSet + PVCs and redeploy
+make down           # delete the Kind cluster
+```
+
+Try a Put/Get through the NodePort:
+
+```
+grpcurl -plaintext localhost:17000 list
+grpcurl -plaintext -d '{"key":"aGVsbG8=","value":"d29ybGQ="}' \
+  localhost:17000 ginnungagap.v1.KvService/Put
+grpcurl -plaintext -d '{"key":"aGVsbG8="}' \
+  localhost:17000 ginnungagap.v1.KvService/Get
+```
+
+The Grafana dashboard should show `ggap_kv_requests_total` climbing within
+~30 seconds (OTel scrape + Prometheus scrape intervals stacked).
+
+## Known limitation: cluster formation
+
+`ggap-node` today single-node-bootstraps a Raft group on any fresh data dir
+(`crates/ggap-node/src/main.rs:238-274`). Because all three pods start from
+empty PVCs and there is no CLI surface to skip that bootstrap, **this deploy
+runs three independent single-node Raft clusters, not one 3-voter quorum**.
+
+The observability pipeline still works as intended — OTel discovers and scrapes
+all three pods, Grafana fans them in side-by-side — and each pod's
+`KvService` is usable on its own.
+
+To exercise true Raft quorum on this harness, scale down to a real single
+node:
+
+```
+kubectl -n ginnungagap scale sts/ggap --replicas=1
+```
+
+Forming an actual 3-voter quorum needs a future `--initial-members` or
+`--seed` flag on `ggap-node` plus either a bootstrap Job or a pre-written
+`bootstrap_members` meta key. That work is tracked for a later pass.
+
+## Caveats
+
+- **No metric history after `make down`** — Prometheus uses an `emptyDir` with
+  1h retention. Data is lost when the pod is deleted.
+- **Dev credentials** — Grafana ships with `admin/admin`. Do not deploy this
+  manifest set outside a local machine.
+- **PVC retention** is `Delete` on StatefulSet deletion for convenience; `make
+  reset` and `make down` both drop ggap data.

--- a/deploy/k8s/bootstrap/job.yaml
+++ b/deploy/k8s/bootstrap/job.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ggap-bootstrap-script
+  namespace: ginnungagap
+data:
+  bootstrap.sh: |
+    #!/bin/sh
+    # Forms a 3-voter Raft cluster on shard 0.
+    #
+    # - ggap-0 runs with --seed and self-initializes as a single-voter cluster.
+    # - ggap-1 and ggap-2 start uninitialized.
+    # - This Job calls AddLearner on ggap-0 for node_ids 2 and 3, then
+    #   ChangeMembership([1,2,3]) to promote them to voters.
+    #
+    # Idempotent: if ClusterStatus already reports >= 3 voters, exits 0.
+    set -eu
+
+    SEED=ggap-0.ggap-headless.ginnungagap.svc.cluster.local:17001
+
+    echo "waiting for seed AdminService at ${SEED}..."
+    i=0
+    while [ $i -lt 60 ]; do
+      if grpcurl -plaintext -max-time 3 "${SEED}" \
+           ginnungagap.v1.AdminService/ClusterStatus >/dev/null 2>&1; then
+        echo "seed reachable"
+        break
+      fi
+      i=$((i + 1))
+      sleep 2
+    done
+    if [ $i -ge 60 ]; then
+      echo "timeout waiting for seed" >&2
+      exit 1
+    fi
+
+    STATUS=$(grpcurl -plaintext -max-time 5 "${SEED}" \
+               ginnungagap.v1.AdminService/ClusterStatus)
+    VOTERS=$(echo "${STATUS}" | grep -c '"nodeId"' || true)
+    if [ "${VOTERS}" -ge 3 ]; then
+      echo "cluster already has ${VOTERS} voters; nothing to do"
+      echo "${STATUS}"
+      exit 0
+    fi
+
+    for id in 2 3; do
+      ord=$((id - 1))
+      addr="ggap-${ord}.ggap-headless.ginnungagap.svc.cluster.local:17001"
+      echo "AddLearner node_id=${id} cluster_addr=${addr}"
+      grpcurl -plaintext -max-time 10 \
+        -d "{\"node\":{\"nodeId\":${id},\"clusterAddr\":\"${addr}\"}}" \
+        "${SEED}" ginnungagap.v1.AdminService/AddLearner
+    done
+
+    echo "ChangeMembership to [1,2,3]"
+    grpcurl -plaintext -max-time 30 \
+      -d '{"nodeIds":[1,2,3]}' \
+      "${SEED}" ginnungagap.v1.AdminService/ChangeMembership
+
+    echo "final ClusterStatus:"
+    grpcurl -plaintext -max-time 5 "${SEED}" \
+      ginnungagap.v1.AdminService/ClusterStatus
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ggap-bootstrap
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: ggap-bootstrap
+spec:
+  backoffLimit: 4
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ggap-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          # The -alpine variant includes /bin/sh; the default tag is distroless
+          # and does not.
+          image: fullstorydev/grpcurl:v1.9.1-alpine
+          command: ["/bin/sh", "/scripts/bootstrap.sh"]
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+      volumes:
+        - name: script
+          configMap:
+            name: ggap-bootstrap-script
+            defaultMode: 0555

--- a/deploy/k8s/ggap/configmap.yaml
+++ b/deploy/k8s/ggap/configmap.yaml
@@ -9,13 +9,22 @@ data:
     set -eu
     ORDINAL="${HOSTNAME##*-}"
     NODE_ID=$((ORDINAL + 1))
-    echo "ggap-node starting: node_id=${NODE_ID} (each pod bootstraps as its own single-node Raft; see deploy/k8s/README.md)"
+    # Only ordinal 0 self-bootstraps shard 0 as a single-voter cluster.
+    # The bootstrap Job then calls AddLearner + ChangeMembership to promote
+    # ordinals 1 and 2 into voters. Restarts are no-ops because ggap-node
+    # checks raft.is_initialized() before re-initializing.
+    SEED_FLAG=""
+    if [ "${ORDINAL}" = "0" ]; then
+      SEED_FLAG="--seed"
+    fi
+    echo "ggap-node starting: node_id=${NODE_ID} seed=${SEED_FLAG:-no}"
     exec /usr/local/bin/ggap-node \
       --node_id "${NODE_ID}" \
       --client_addr 0.0.0.0:17000 \
       --cluster_addr 0.0.0.0:17001 \
       --data_dir /var/lib/ginnungagap \
       --metrics_addr 0.0.0.0:9090 \
+      ${SEED_FLAG} \
       --peer 1=ggap-0.ggap-headless.ginnungagap.svc.cluster.local:17001 \
       --peer 2=ggap-1.ggap-headless.ginnungagap.svc.cluster.local:17001 \
       --peer 3=ggap-2.ggap-headless.ginnungagap.svc.cluster.local:17001

--- a/deploy/k8s/ggap/configmap.yaml
+++ b/deploy/k8s/ggap/configmap.yaml
@@ -19,11 +19,11 @@ data:
     fi
     echo "ggap-node starting: node_id=${NODE_ID} seed=${SEED_FLAG:-no}"
     exec /usr/local/bin/ggap-node \
-      --node_id "${NODE_ID}" \
-      --client_addr 0.0.0.0:17000 \
-      --cluster_addr 0.0.0.0:17001 \
-      --data_dir /var/lib/ginnungagap \
-      --metrics_addr 0.0.0.0:9090 \
+      --node-id "${NODE_ID}" \
+      --client-addr 0.0.0.0:17000 \
+      --cluster-addr $( hostname -i ):17001 \
+      --data-dir /var/lib/ginnungagap \
+      --metrics-addr 0.0.0.0:9090 \
       ${SEED_FLAG} \
       --peer 1=ggap-0.ggap-headless.ginnungagap.svc.cluster.local:17001 \
       --peer 2=ggap-1.ggap-headless.ginnungagap.svc.cluster.local:17001 \

--- a/deploy/k8s/ggap/configmap.yaml
+++ b/deploy/k8s/ggap/configmap.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ggap-entrypoint
+  namespace: ginnungagap
+data:
+  run.sh: |
+    #!/bin/sh
+    set -eu
+    ORDINAL="${HOSTNAME##*-}"
+    NODE_ID=$((ORDINAL + 1))
+    echo "ggap-node starting: node_id=${NODE_ID} (each pod bootstraps as its own single-node Raft; see deploy/k8s/README.md)"
+    exec /usr/local/bin/ggap-node \
+      --node_id "${NODE_ID}" \
+      --client_addr 0.0.0.0:17000 \
+      --cluster_addr 0.0.0.0:17001 \
+      --data_dir /var/lib/ginnungagap \
+      --metrics_addr 0.0.0.0:9090 \
+      --peer 1=ggap-0.ggap-headless.ginnungagap.svc.cluster.local:17001 \
+      --peer 2=ggap-1.ggap-headless.ginnungagap.svc.cluster.local:17001 \
+      --peer 3=ggap-2.ggap-headless.ginnungagap.svc.cluster.local:17001

--- a/deploy/k8s/ggap/service-client.yaml
+++ b/deploy/k8s/ggap/service-client.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ggap
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: ggap-node
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: ggap-node
+  ports:
+    - name: client
+      port: 17000
+      targetPort: client
+      nodePort: 30700

--- a/deploy/k8s/ggap/service-headless.yaml
+++ b/deploy/k8s/ggap/service-headless.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ggap-headless
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: ggap-node
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: ggap-node
+  ports:
+    - name: cluster
+      port: 17001
+      targetPort: cluster
+    - name: metrics
+      port: 9090
+      targetPort: metrics

--- a/deploy/k8s/ggap/statefulset.yaml
+++ b/deploy/k8s/ggap/statefulset.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ggap
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: ggap-node
+spec:
+  serviceName: ggap-headless
+  replicas: 3
+  podManagementPolicy: Parallel
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ggap-node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ggap-node
+    spec:
+      terminationGracePeriodSeconds: 20
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: ggap-node
+      containers:
+        - name: ggap-node
+          image: ginnungagap:dev
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "/etc/ggap/run.sh"]
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: GINNUNGAGAP_OBSERVABILITY__LOG_FORMAT
+              value: pretty
+          ports:
+            - name: client
+              containerPort: 17000
+            - name: cluster
+              containerPort: 17001
+            - name: metrics
+              containerPort: 9090
+          readinessProbe:
+            tcpSocket:
+              port: cluster
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: cluster
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/ginnungagap
+            - name: entrypoint
+              mountPath: /etc/ggap
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1
+              memory: 512Mi
+      volumes:
+        - name: entrypoint
+          configMap:
+            name: ggap-entrypoint
+            defaultMode: 0555
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/deploy/k8s/grafana/configmap-dashboards.yaml
+++ b/deploy/k8s/grafana/configmap-dashboards.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  namespace: ginnungagap
+data:
+  providers.yaml: |
+    apiVersion: 1
+    providers:
+      - name: ginnungagap
+        orgId: 1
+        folder: Ginnungagap
+        type: file
+        disableDeletion: false
+        allowUiUpdates: true
+        options:
+          path: /var/lib/grafana/dashboards
+  ginnungagap.json: |
+    {
+      "title": "Ginnungagap — Overview",
+      "uid": "ginnungagap-overview",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "10s",
+      "time": {"from": "now-15m", "to": "now"},
+      "tags": ["ginnungagap"],
+      "timezone": "",
+      "templating": {"list": []},
+      "annotations": {"list": []},
+      "panels": [
+        {
+          "id": 1,
+          "type": "timeseries",
+          "title": "KV request rate (req/s) by method",
+          "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "sum by (method) (rate(ggap_kv_requests_total[1m]))",
+              "legendFormat": "{{method}}"
+            }
+          ],
+          "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}}
+        },
+        {
+          "id": 2,
+          "type": "timeseries",
+          "title": "KV request rate by pod",
+          "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "sum by (pod) (rate(ggap_kv_requests_total[1m]))",
+              "legendFormat": "{{pod}}"
+            }
+          ],
+          "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}}
+        },
+        {
+          "id": 3,
+          "type": "timeseries",
+          "title": "KV request latency p50 / p99 (seconds)",
+          "gridPos": {"x": 0, "y": 8, "w": 12, "h": 8},
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "histogram_quantile(0.5, sum by (le, method) (rate(ggap_kv_request_duration_seconds_bucket[5m])))",
+              "legendFormat": "p50 {{method}}"
+            },
+            {
+              "refId": "B",
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "histogram_quantile(0.99, sum by (le, method) (rate(ggap_kv_request_duration_seconds_bucket[5m])))",
+              "legendFormat": "p99 {{method}}"
+            }
+          ],
+          "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}}
+        },
+        {
+          "id": 4,
+          "type": "timeseries",
+          "title": "Non-OK gRPC status by method",
+          "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8},
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "sum by (method, status) (rate(ggap_kv_requests_total{status!=\"OK\"}[1m]))",
+              "legendFormat": "{{method}} / {{status}}"
+            }
+          ],
+          "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "showLegend": true}}
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "ggap pods scraped (up)",
+          "gridPos": {"x": 0, "y": 16, "w": 8, "h": 4},
+          "targets": [
+            {
+              "refId": "A",
+              "datasource": {"type": "prometheus", "uid": "prometheus"},
+              "expr": "count(up{job=\"otel-collector\"} == 1)"
+            }
+          ],
+          "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+          "options": {"graphMode": "none"}
+        }
+      ]
+    }

--- a/deploy/k8s/grafana/configmap-datasource.yaml
+++ b/deploy/k8s/grafana/configmap-datasource.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: ginnungagap
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        # The OTel Collector scrapes ggap pods and re-exposes on :8889.
+        # Prometheus scrapes the Collector. Grafana queries Prometheus.
+        url: http://prometheus.ginnungagap.svc.cluster.local:9090
+        isDefault: true
+        editable: false

--- a/deploy/k8s/grafana/deployment.yaml
+++ b/deploy/k8s/grafana/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.2.0
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: admin
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: admin
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Viewer
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+          ports:
+            - name: http
+              containerPort: 3000
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+              readOnly: true
+            - name: dashboards-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+              readOnly: true
+            - name: dashboards-json
+              mountPath: /var/lib/grafana/dashboards
+              readOnly: true
+            - name: grafana-storage
+              mountPath: /var/lib/grafana
+              subPath: storage
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboards-provider
+          configMap:
+            name: grafana-dashboards
+            items:
+              - key: providers.yaml
+                path: providers.yaml
+        - name: dashboards-json
+          configMap:
+            name: grafana-dashboards
+            items:
+              - key: ginnungagap.json
+                path: ginnungagap.json
+        - name: grafana-storage
+          emptyDir: {}

--- a/deploy/k8s/grafana/service.yaml
+++ b/deploy/k8s/grafana/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: grafana
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      nodePort: 30300

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - ggap/configmap.yaml
+  - ggap/service-headless.yaml
+  - ggap/service-client.yaml
+  - ggap/statefulset.yaml
+  - otel/rbac.yaml
+  - otel/configmap.yaml
+  - otel/deployment.yaml
+  - otel/service.yaml
+  - prometheus/configmap.yaml
+  - prometheus/deployment.yaml
+  - prometheus/service.yaml
+  - grafana/configmap-datasource.yaml
+  - grafana/configmap-dashboards.yaml
+  - grafana/deployment.yaml
+  - grafana/service.yaml

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ginnungagap

--- a/deploy/k8s/otel/configmap.yaml
+++ b/deploy/k8s/otel/configmap.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: ginnungagap
+data:
+  config.yaml: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: ggap
+              # ggap-node serves its Prometheus metrics at '/', not '/metrics'.
+              metrics_path: /
+              scrape_interval: 15s
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names: [ginnungagap]
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+                  action: keep
+                  regex: ggap-node
+                - source_labels: [__meta_kubernetes_pod_container_port_name]
+                  action: keep
+                  regex: metrics
+                - source_labels: [__meta_kubernetes_pod_name]
+                  target_label: pod
+                - source_labels: [__meta_kubernetes_namespace]
+                  target_label: namespace
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+
+    processors:
+      batch:
+        timeout: 10s
+
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        resource_to_telemetry_conversion:
+          enabled: true
+      debug:
+        verbosity: basic
+
+    service:
+      telemetry:
+        logs:
+          level: info
+        metrics:
+          address: 0.0.0.0:8888
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [batch]
+          exporters: [prometheus, debug]

--- a/deploy/k8s/otel/deployment.yaml
+++ b/deploy/k8s/otel/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: otel-collector
+    spec:
+      serviceAccountName: otel-collector
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.110.0
+          args: ["--config=/etc/otel/config.yaml"]
+          ports:
+            - name: self-metrics
+              containerPort: 8888
+            - name: exported
+              containerPort: 8889
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config

--- a/deploy/k8s/otel/rbac.yaml
+++ b/deploy/k8s/otel/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  namespace: ginnungagap
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ginnungagap-otel-collector
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - endpoints
+      - namespaces
+      - nodes
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ginnungagap-otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ginnungagap-otel-collector
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector
+    namespace: ginnungagap

--- a/deploy/k8s/otel/service.yaml
+++ b/deploy/k8s/otel/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: otel-collector
+spec:
+  selector:
+    app.kubernetes.io/name: otel-collector
+  ports:
+    - name: self-metrics
+      port: 8888
+      targetPort: self-metrics
+    - name: exported
+      port: 8889
+      targetPort: exported

--- a/deploy/k8s/prometheus/configmap.yaml
+++ b/deploy/k8s/prometheus/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: ginnungagap
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+      # The OTel Collector does the actual scraping of ggap pods and
+      # re-exposes them at :8889. Prometheus only scrapes that single
+      # endpoint, acting as the PromQL/TSDB layer for Grafana.
+      - job_name: otel-collector
+        static_configs:
+          - targets:
+              - otel-collector.ginnungagap.svc.cluster.local:8889
+      # Collector self-metrics (pipeline stats, scrape success rate, etc.)
+      - job_name: otel-collector-self
+        static_configs:
+          - targets:
+              - otel-collector.ginnungagap.svc.cluster.local:8888

--- a/deploy/k8s/prometheus/deployment.yaml
+++ b/deploy/k8s/prometheus/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.54.0
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=1h
+            - --web.enable-lifecycle
+          ports:
+            - name: http
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 15
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}

--- a/deploy/k8s/prometheus/service.yaml
+++ b/deploy/k8s/prometheus/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: prometheus
+spec:
+  selector:
+    app.kubernetes.io/name: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http

--- a/deploy/kind/kind-config.yaml
+++ b/deploy/kind/kind-config.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ggap
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30300
+        hostPort: 3000
+        protocol: TCP
+      - containerPort: 30700
+        hostPort: 17000
+        protocol: TCP
+  - role: worker
+  - role: worker
+  - role: worker

--- a/deploy/scripts/kind-up.sh
+++ b/deploy/scripts/kind-up.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+exec make up


### PR DESCRIPTION
Spins up a 1 control-plane + 3 worker Kind cluster and deploys three
ggap-node pods alongside an OpenTelemetry Collector, Prometheus, and
Grafana. The Collector discovers ggap pods via the Kubernetes SD
prometheus receiver and re-exposes their metrics on :8889 (using
metrics_path: / since ggap-node serves at the root, not /metrics);
Prometheus scrapes the Collector to back Grafana with PromQL.

Cluster formation caveat: ggap-node single-node-bootstraps on any
fresh data dir, so the three pods run as three independent single-node
Raft clusters. A real 3-voter quorum needs a future --initial-members
or --seed flag on ggap-node; documented in deploy/README.md.

No Rust changes. `make up` is the one-shot bring-up.