### PR TITLE
Remove TLS/mTLS task from implementation plan

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -313,7 +313,6 @@ turmoil                     = "0.6"   # dev-dependency; simulation harness (Phas
 - [x] Chaos tests: kill leader + verify re-election, network partition + heal, message drops with concurrent writes, membership change under partition — all covered by DST suite
 - [ ] Prometheus metrics: request rate/latency p50/p99, Raft term, commit lag, match index
 - [ ] OpenTelemetry trace propagation (client → server → consensus)
-- [ ] TLS/mTLS for external and internal gRPC
 - [x] Admin RPCs: `ClusterStatus` (reads Raft metrics for term, leader, last_applied, voter membership), `AddLearner` (adds non-voting learner via openraft), `ChangeMembership` (replaces voter set via joint-consensus). All wired through `ShardRouter` → `OpenRaftNode` → openraft APIs
 
 ---


### PR DESCRIPTION
## Summary
This change removes the TLS/mTLS implementation task from the project plan, indicating that this feature is either being deferred or deprioritized at this time.

## Changes Made
- Removed the unchecked task item "TLS/mTLS for external and internal gRPC" from the PLAN.md roadmap

## Context
The TLS/mTLS task was listed as a future work item in the security/infrastructure section of the implementation plan. This removal suggests a decision to focus on other priorities or defer this security enhancement to a later phase of development.

https://claude.ai/code/session_019qFrLBkQG6V2DdoDfWrGaG