### PR TITLE
feat: OTel-aligned RPC latency metrics across all gRPC services

### DIFF
--- a/crates/ggap-server/src/admin_service.rs
+++ b/crates/ggap-server/src/admin_service.rs
@@ -12,6 +12,7 @@ use ggap_storage::ShardMap;
 use tonic::{Request, Response, Status};
 
 use crate::convert::ggap_to_status;
+use crate::metrics::record;
 
 pub struct AdminServiceImpl {
     router: Arc<ShardRouter>,
@@ -41,13 +42,10 @@ impl AdminServiceImpl {
             .await
             .ok_or_else(|| Status::internal("shard 0 not found in router"))
     }
-}
 
-#[tonic::async_trait]
-impl AdminService for AdminServiceImpl {
-    async fn cluster_status(
+    async fn do_cluster_status(
         &self,
-        _request: Request<ClusterStatusRequest>,
+        _req: ClusterStatusRequest,
     ) -> Result<Response<ClusterStatusResponse>, Status> {
         let node = self.shard0_node().await?;
         let status = node.cluster_status();
@@ -67,11 +65,10 @@ impl AdminService for AdminServiceImpl {
         }))
     }
 
-    async fn add_learner(
+    async fn do_add_learner(
         &self,
-        request: Request<AddLearnerRequest>,
+        req: AddLearnerRequest,
     ) -> Result<Response<AddLearnerResponse>, Status> {
-        let req = request.into_inner();
         let node_info = req
             .node
             .ok_or_else(|| Status::invalid_argument("node must be provided"))?;
@@ -104,11 +101,10 @@ impl AdminService for AdminServiceImpl {
         }
     }
 
-    async fn change_membership(
+    async fn do_change_membership(
         &self,
-        request: Request<ChangeMembershipRequest>,
+        req: ChangeMembershipRequest,
     ) -> Result<Response<ChangeMembershipResponse>, Status> {
-        let req = request.into_inner();
         if req.node_ids.is_empty() {
             return Err(Status::invalid_argument(
                 "node_ids must contain at least one voter",
@@ -134,11 +130,10 @@ impl AdminService for AdminServiceImpl {
         }
     }
 
-    async fn split_shard(
+    async fn do_split_shard(
         &self,
-        request: Request<SplitShardRequest>,
+        req: SplitShardRequest,
     ) -> Result<Response<SplitShardResponse>, Status> {
-        let req = request.into_inner();
         if req.split_key.is_empty() {
             return Err(Status::invalid_argument("split_key must not be empty"));
         }
@@ -166,9 +161,9 @@ impl AdminService for AdminServiceImpl {
         }
     }
 
-    async fn list_shards(
+    async fn do_list_shards(
         &self,
-        _request: Request<ListShardsRequest>,
+        _req: ListShardsRequest,
     ) -> Result<Response<ListShardsResponse>, Status> {
         let shards = self.shard_map.all_shards().await;
         let protos = shards
@@ -181,5 +176,78 @@ impl AdminService for AdminServiceImpl {
             })
             .collect();
         Ok(Response::new(ListShardsResponse { shards: protos }))
+    }
+}
+
+#[tonic::async_trait]
+impl AdminService for AdminServiceImpl {
+    async fn cluster_status(
+        &self,
+        request: Request<ClusterStatusRequest>,
+    ) -> Result<Response<ClusterStatusResponse>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_cluster_status(request.into_inner()).await;
+        record(
+            "ginnungagap.v1.AdminService/ClusterStatus",
+            &result,
+            start.elapsed(),
+        );
+        result
+    }
+
+    async fn add_learner(
+        &self,
+        request: Request<AddLearnerRequest>,
+    ) -> Result<Response<AddLearnerResponse>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_add_learner(request.into_inner()).await;
+        record(
+            "ginnungagap.v1.AdminService/AddLearner",
+            &result,
+            start.elapsed(),
+        );
+        result
+    }
+
+    async fn change_membership(
+        &self,
+        request: Request<ChangeMembershipRequest>,
+    ) -> Result<Response<ChangeMembershipResponse>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_change_membership(request.into_inner()).await;
+        record(
+            "ginnungagap.v1.AdminService/ChangeMembership",
+            &result,
+            start.elapsed(),
+        );
+        result
+    }
+
+    async fn split_shard(
+        &self,
+        request: Request<SplitShardRequest>,
+    ) -> Result<Response<SplitShardResponse>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_split_shard(request.into_inner()).await;
+        record(
+            "ginnungagap.v1.AdminService/SplitShard",
+            &result,
+            start.elapsed(),
+        );
+        result
+    }
+
+    async fn list_shards(
+        &self,
+        request: Request<ListShardsRequest>,
+    ) -> Result<Response<ListShardsResponse>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_list_shards(request.into_inner()).await;
+        record(
+            "ginnungagap.v1.AdminService/ListShards",
+            &result,
+            start.elapsed(),
+        );
+        result
     }
 }

--- a/crates/ggap-server/src/kv_service.rs
+++ b/crates/ggap-server/src/kv_service.rs
@@ -229,14 +229,14 @@ impl KvService for KvServiceImpl {
     async fn get(&self, request: Request<GetRequest>) -> Result<Response<GetResponse>, Status> {
         let start = tokio::time::Instant::now();
         let result = self.do_get(request.into_inner()).await;
-        record("get", &result, start.elapsed());
+        record("ginnungagap.v1.KvService/Get", &result, start.elapsed());
         result
     }
 
     async fn put(&self, request: Request<PutRequest>) -> Result<Response<PutResponse>, Status> {
         let start = tokio::time::Instant::now();
         let result = self.do_put(request.into_inner()).await;
-        record("put", &result, start.elapsed());
+        record("ginnungagap.v1.KvService/Put", &result, start.elapsed());
         result
     }
 
@@ -246,14 +246,14 @@ impl KvService for KvServiceImpl {
     ) -> Result<Response<DeleteResponse>, Status> {
         let start = tokio::time::Instant::now();
         let result = self.do_delete(request.into_inner()).await;
-        record("delete", &result, start.elapsed());
+        record("ginnungagap.v1.KvService/Delete", &result, start.elapsed());
         result
     }
 
     async fn scan(&self, request: Request<ScanRequest>) -> Result<Response<ScanResponse>, Status> {
         let start = tokio::time::Instant::now();
         let result = self.do_scan(request.into_inner()).await;
-        record("scan", &result, start.elapsed());
+        record("ginnungagap.v1.KvService/Scan", &result, start.elapsed());
         result
     }
 
@@ -263,12 +263,18 @@ impl KvService for KvServiceImpl {
     ) -> Result<Response<CasResponse>, Status> {
         let start = tokio::time::Instant::now();
         let result = self.do_compare_and_swap(request.into_inner()).await;
-        record("compare_and_swap", &result, start.elapsed());
+        record(
+            "ginnungagap.v1.KvService/CompareAndSwap",
+            &result,
+            start.elapsed(),
+        );
         result
     }
 
     type WatchStream = ReceiverStream<Result<WatchEvent, Status>>;
 
+    // Watch is intentionally uninstrumented: stream session lifetime is not
+    // an RPC request duration (mixing would skew p99).
     async fn watch(
         &self,
         request: Request<Streaming<WatchRequest>>,

--- a/crates/ggap-server/src/metrics.rs
+++ b/crates/ggap-server/src/metrics.rs
@@ -1,27 +1,49 @@
+//! OpenTelemetry-aligned Prometheus metrics for inbound gRPC calls.
+//!
+//! Metric: [`rpc.server.call.duration`][spec] (histogram, unit: seconds).
+//! Prometheus exposition name: `rpc_server_call_duration_seconds` —
+//! `.`→`_` sanitization plus the `_seconds` unit suffix.
+//!
+//! Attributes (written with their canonical OTel dotted names; the Prometheus
+//! exporter sanitizes `.` to `_` on export):
+//!
+//! - `rpc.system.name = "grpc"`
+//! - `rpc.method` — **fully qualified** `<package>.<service>/<Method>`, e.g.
+//!   `"ginnungagap.v1.KvService/Get"`. The separate `rpc.service` attribute
+//!   is intentionally folded into `rpc.method` here so queries only need one
+//!   label to identify a call site.
+//! - `rpc.response.status_code` — numeric gRPC status code (0–16) stringified.
+//!
+//! Request count is derived from the histogram's `_count` suffix; no separate
+//! counter is emitted.
+//!
+//! [spec]: https://opentelemetry.io/docs/specs/semconv/rpc/rpc-metrics/
+
 use std::sync::Arc;
 use std::time::Duration;
 
 use tonic::Status;
 
-/// Counter: total number of `KvService` unary RPCs completed, labeled by method and status.
-pub const RPC_TOTAL: &str = "ggap_kv_requests_total";
+/// OTel canonical metric ID: `rpc.server.call.duration` (seconds).
+pub const RPC_SERVER_CALL_DURATION: &str = "rpc_server_call_duration_seconds";
 
-/// Histogram: `KvService` unary RPC latency in seconds, labeled by method and status.
-pub const RPC_DURATION: &str = "ggap_kv_request_duration_seconds";
-
-/// Record a counter increment and a latency observation for one RPC.
+/// Record a latency observation for one inbound gRPC call.
 ///
-/// The `status` label is the native `tonic::Code` variant name (e.g. `"Ok"`,
-/// `"NotFound"`, `"InvalidArgument"`) taken directly from `{:?}`; no
-/// intermediate bucketing or case-conversion.
+/// `method` is the fully qualified gRPC method, e.g.
+/// `"ginnungagap.v1.KvService/Get"`.
 pub fn record<T>(method: &'static str, result: &Result<T, Status>, elapsed: Duration) {
-    let code = result
+    let code: i32 = result
         .as_ref()
         .err()
         .map(|s| s.code())
-        .unwrap_or(tonic::Code::Ok);
-    let status: Arc<str> = format!("{code:?}").into();
-    metrics::counter!(RPC_TOTAL, "method" => method, "status" => status.clone()).increment(1);
-    metrics::histogram!(RPC_DURATION, "method" => method, "status" => status)
-        .record(elapsed.as_secs_f64());
+        .unwrap_or(tonic::Code::Ok)
+        .into();
+    let status_code: Arc<str> = code.to_string().into();
+    metrics::histogram!(
+        RPC_SERVER_CALL_DURATION,
+        "rpc.system.name" => "grpc",
+        "rpc.method" => method,
+        "rpc.response.status_code" => status_code,
+    )
+    .record(elapsed.as_secs_f64());
 }

--- a/crates/ggap-server/src/raft_service.rs
+++ b/crates/ggap-server/src/raft_service.rs
@@ -5,6 +5,7 @@ use ggap_proto::v1::{raft_service_server::RaftService, RaftMessage};
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::convert::ggap_to_status;
+use crate::metrics::record;
 
 pub struct RaftServiceImpl {
     router: Arc<ShardRouter>,
@@ -14,15 +15,8 @@ impl RaftServiceImpl {
     pub fn new(router: Arc<ShardRouter>) -> Self {
         RaftServiceImpl { router }
     }
-}
 
-#[tonic::async_trait]
-impl RaftService for RaftServiceImpl {
-    async fn append_entries(
-        &self,
-        request: Request<RaftMessage>,
-    ) -> Result<Response<RaftMessage>, Status> {
-        let msg = request.into_inner();
+    async fn do_append_entries(&self, msg: RaftMessage) -> Result<Response<RaftMessage>, Status> {
         let cluster = self
             .router
             .get_cluster(msg.shard_id)
@@ -38,8 +32,7 @@ impl RaftService for RaftServiceImpl {
         }))
     }
 
-    async fn vote(&self, request: Request<RaftMessage>) -> Result<Response<RaftMessage>, Status> {
-        let msg = request.into_inner();
+    async fn do_vote(&self, msg: RaftMessage) -> Result<Response<RaftMessage>, Status> {
         let cluster = self
             .router
             .get_cluster(msg.shard_id)
@@ -52,11 +45,10 @@ impl RaftService for RaftServiceImpl {
         }))
     }
 
-    async fn install_snapshot(
+    async fn do_install_snapshot(
         &self,
-        request: Request<Streaming<RaftMessage>>,
+        mut stream: Streaming<RaftMessage>,
     ) -> Result<Response<RaftMessage>, Status> {
-        let mut stream = request.into_inner();
         let mut last_resp: Option<Vec<u8>> = None;
         let mut shard_id = 0u64;
 
@@ -75,5 +67,43 @@ impl RaftService for RaftServiceImpl {
 
         let data = last_resp.unwrap_or_default();
         Ok(Response::new(RaftMessage { shard_id, data }))
+    }
+}
+
+#[tonic::async_trait]
+impl RaftService for RaftServiceImpl {
+    async fn append_entries(
+        &self,
+        request: Request<RaftMessage>,
+    ) -> Result<Response<RaftMessage>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_append_entries(request.into_inner()).await;
+        record(
+            "ginnungagap.v1.RaftService/AppendEntries",
+            &result,
+            start.elapsed(),
+        );
+        result
+    }
+
+    async fn vote(&self, request: Request<RaftMessage>) -> Result<Response<RaftMessage>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_vote(request.into_inner()).await;
+        record("ginnungagap.v1.RaftService/Vote", &result, start.elapsed());
+        result
+    }
+
+    async fn install_snapshot(
+        &self,
+        request: Request<Streaming<RaftMessage>>,
+    ) -> Result<Response<RaftMessage>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_install_snapshot(request.into_inner()).await;
+        record(
+            "ginnungagap.v1.RaftService/InstallSnapshot",
+            &result,
+            start.elapsed(),
+        );
+        result
     }
 }

--- a/crates/ggap-server/tests/rpc_metrics.rs
+++ b/crates/ggap-server/tests/rpc_metrics.rs
@@ -1,12 +1,12 @@
-//! Verifies that `KvService` unary RPCs emit the expected Prometheus metric
-//! series. A single-node in-process Raft cluster is started, a `DebuggingRecorder`
-//! is installed process-globally (guarded by `OnceLock` — this is the only test
-//! in the workspace that installs a metrics recorder), and each RPC is exercised
-//! against a tonic client connected to a loopback listener.
+//! Verifies that inbound gRPC calls on all three services (`KvService`,
+//! `AdminService`, `RaftService`) emit the OTel-aligned Prometheus histogram
+//! `rpc_server_call_duration_seconds` with the expected `(rpc.method,
+//! rpc.response.status_code)` label pairs.
 //!
-//! Asserts the `(method, status)` label pairs on `ggap_kv_requests_total` and
-//! that `ggap_kv_request_duration_seconds` records at least one observation
-//! per invocation.
+//! A single-node in-process Raft cluster is started, a `DebuggingRecorder` is
+//! installed process-globally (guarded by `OnceLock` — this is the only test
+//! in the workspace that installs a metrics recorder), and each service is
+//! exercised against a tonic client connected to a loopback listener.
 
 use std::collections::{BTreeMap, HashMap};
 use std::net::SocketAddr;
@@ -24,12 +24,15 @@ use ggap_consensus::{
     OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
 use ggap_proto::v1::{
-    kv_service_client::KvServiceClient, CasRequest, DeleteRequest, GetRequest, PutRequest,
-    ScanRequest,
+    admin_service_client::AdminServiceClient, kv_service_client::KvServiceClient,
+    raft_service_client::RaftServiceClient, AddLearnerRequest, CasRequest, ClusterStatusRequest,
+    DeleteRequest, GetRequest, ListShardsRequest, NodeInfo, PutRequest, RaftMessage, ScanRequest,
 };
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener, KvServiceConfig};
 use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
 use ggap_storage::ShardMap;
+
+const METRIC: &str = "rpc_server_call_duration_seconds";
 
 static SNAPSHOTTER: OnceLock<Snapshotter> = OnceLock::new();
 
@@ -46,6 +49,7 @@ fn install_recorder() -> &'static Snapshotter {
 
 struct TestNode {
     client_addr: SocketAddr,
+    cluster_addr: SocketAddr,
     raft: Arc<GgapRaft>,
     _handles: Vec<tokio::task::JoinHandle<()>>,
     _tempdir: TempDir,
@@ -134,18 +138,19 @@ async fn start_single_node() -> TestNode {
 
     TestNode {
         client_addr,
+        cluster_addr,
         raft,
         _handles: handles,
         _tempdir: tempdir,
     }
 }
 
-/// Collect `ggap_kv_requests_total` samples into a `{(method, status) -> count}` map.
-fn counter_totals(snap: &Snapshotter) -> HashMap<(String, String), u64> {
+/// Collect histogram observation counts keyed by `(rpc.method, rpc.response.status_code)`.
+fn duration_counts(snap: &Snapshotter) -> HashMap<(String, String), usize> {
     let mut out = HashMap::new();
     for (key, _unit, _desc, value) in snap.snapshot().into_vec() {
         let (_kind, k) = key.into_parts();
-        if k.name() != "ggap_kv_requests_total" {
+        if k.name() != METRIC {
             continue;
         }
         let mut method = None;
@@ -153,74 +158,74 @@ fn counter_totals(snap: &Snapshotter) -> HashMap<(String, String), u64> {
         for label in k.labels() {
             let label: &metrics::Label = label;
             match label.key() {
-                "method" => method = Some(label.value().to_string()),
-                "status" => status = Some(label.value().to_string()),
+                "rpc.method" => method = Some(label.value().to_string()),
+                "rpc.response.status_code" => status = Some(label.value().to_string()),
                 _ => {}
             }
         }
         if let (Some(m), Some(s)) = (method, status) {
-            if let DebugValue::Counter(c) = value {
-                *out.entry((m, s)).or_insert(0) += c;
+            if let DebugValue::Histogram(values) = value {
+                *out.entry((m, s)).or_insert(0) += values.len();
             }
         }
     }
     out
 }
 
-/// Count distinct `(method, status)` tuples seen on the histogram metric.
-fn histogram_method_statuses(snap: &Snapshotter) -> Vec<(String, String)> {
-    let mut out = Vec::new();
+/// Verify every `rpc_server_call_duration_seconds` series carries
+/// `rpc.system.name = "grpc"`.
+fn assert_grpc_system(snap: &Snapshotter) {
     for (key, _unit, _desc, _value) in snap.snapshot().into_vec() {
         let (_kind, k) = key.into_parts();
-        if k.name() != "ggap_kv_request_duration_seconds" {
+        if k.name() != METRIC {
             continue;
         }
-        let mut method = None;
-        let mut status = None;
-        for label in k.labels() {
-            let label: &metrics::Label = label;
-            match label.key() {
-                "method" => method = Some(label.value().to_string()),
-                "status" => status = Some(label.value().to_string()),
-                _ => {}
-            }
-        }
-        if let (Some(m), Some(s)) = (method, status) {
-            out.push((m, s));
-        }
+        let has_grpc = k
+            .labels()
+            .any(|l| l.key() == "rpc.system.name" && l.value() == "grpc");
+        assert!(
+            has_grpc,
+            "series missing rpc.system.name=grpc: labels={:?}",
+            k.labels().collect::<Vec<_>>()
+        );
     }
-    out
+}
+
+fn has(counts: &HashMap<(String, String), usize>, method: &str, status: &str) -> bool {
+    counts
+        .get(&(method.to_string(), status.to_string()))
+        .copied()
+        .unwrap_or(0)
+        >= 1
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn kv_service_emits_metrics_for_each_rpc() {
+async fn all_services_emit_rpc_server_call_duration_metrics() {
     let snap = install_recorder();
     let node = start_single_node().await;
 
-    let endpoint = format!("http://{}", node.client_addr);
-    let mut client = KvServiceClient::connect(endpoint)
+    let client_endpoint = format!("http://{}", node.client_addr);
+    let cluster_endpoint = format!("http://{}", node.cluster_addr);
+
+    // ---------- KvService ----------
+    let mut kv = KvServiceClient::connect(client_endpoint)
         .await
         .expect("connect to kv service");
 
-    // ok: Put + Get
-    client
-        .put(PutRequest {
-            key: "a".into(),
-            value: b"1".to_vec(),
-            ..Default::default()
-        })
-        .await
-        .expect("put ok");
-    client
-        .get(GetRequest {
-            key: "a".into(),
-            ..Default::default()
-        })
-        .await
-        .expect("get ok");
-
-    // not_found: Get missing key
-    let err = client
+    kv.put(PutRequest {
+        key: "a".into(),
+        value: b"1".to_vec(),
+        ..Default::default()
+    })
+    .await
+    .expect("put ok");
+    kv.get(GetRequest {
+        key: "a".into(),
+        ..Default::default()
+    })
+    .await
+    .expect("get ok");
+    let err = kv
         .get(GetRequest {
             key: "missing".into(),
             ..Default::default()
@@ -228,9 +233,7 @@ async fn kv_service_emits_metrics_for_each_rpc() {
         .await
         .unwrap_err();
     assert_eq!(err.code(), tonic::Code::NotFound);
-
-    // invalid: Put with empty key
-    let err = client
+    let err = kv
         .put(PutRequest {
             key: "".into(),
             value: b"x".to_vec(),
@@ -239,9 +242,7 @@ async fn kv_service_emits_metrics_for_each_rpc() {
         .await
         .unwrap_err();
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
-
-    // conflict: Put with stale expect_version
-    let err = client
+    let err = kv
         .put(PutRequest {
             key: "a".into(),
             value: b"2".to_vec(),
@@ -251,66 +252,123 @@ async fn kv_service_emits_metrics_for_each_rpc() {
         .await
         .unwrap_err();
     assert_eq!(err.code(), tonic::Code::Aborted);
+    kv.delete(DeleteRequest {
+        key: "a".into(),
+        ..Default::default()
+    })
+    .await
+    .expect("delete ok");
+    kv.scan(ScanRequest {
+        start_key: "".into(),
+        end_key: "".into(),
+        limit: 10,
+        ..Default::default()
+    })
+    .await
+    .expect("scan ok");
+    kv.compare_and_swap(CasRequest {
+        key: "b".into(),
+        expected_value: b"".to_vec(),
+        new_value: b"v".to_vec(),
+        ..Default::default()
+    })
+    .await
+    .expect("cas ok");
 
-    // ok: Delete, Scan, CompareAndSwap
-    client
-        .delete(DeleteRequest {
-            key: "a".into(),
-            ..Default::default()
+    // ---------- AdminService ----------
+    let mut admin = AdminServiceClient::connect(cluster_endpoint.clone())
+        .await
+        .expect("connect to admin service");
+    admin
+        .cluster_status(ClusterStatusRequest {})
+        .await
+        .expect("cluster_status ok");
+    admin
+        .list_shards(ListShardsRequest {})
+        .await
+        .expect("list_shards ok");
+    let err = admin
+        .add_learner(AddLearnerRequest {
+            node: Some(NodeInfo {
+                node_id: 0,
+                client_addr: String::new(),
+                cluster_addr: "127.0.0.1:1".into(),
+            }),
         })
         .await
-        .expect("delete ok");
-    client
-        .scan(ScanRequest {
-            start_key: "".into(),
-            end_key: "".into(),
-            limit: 10,
-            ..Default::default()
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    // ---------- RaftService ----------
+    let mut raft_client = RaftServiceClient::connect(cluster_endpoint)
+        .await
+        .expect("connect to raft service");
+    let err = raft_client
+        .vote(RaftMessage {
+            shard_id: 999,
+            data: Vec::new(),
         })
         .await
-        .expect("scan ok");
-    client
-        .compare_and_swap(CasRequest {
-            key: "b".into(),
-            expected_value: b"".to_vec(),
-            new_value: b"v".to_vec(),
-            ..Default::default()
-        })
-        .await
-        .expect("cas ok");
+        .unwrap_err();
+    assert_eq!(err.code(), tonic::Code::NotFound);
 
-    let totals = counter_totals(snap);
-    let get = |m: &str, s: &str| *totals.get(&(m.to_string(), s.to_string())).unwrap_or(&0);
+    // ---------- Assertions ----------
+    let counts = duration_counts(snap);
+    assert_grpc_system(snap);
 
-    assert!(get("put", "Ok") >= 1, "put Ok missing: {totals:?}");
-    assert!(get("get", "Ok") >= 1, "get Ok missing: {totals:?}");
+    // KvService
     assert!(
-        get("get", "NotFound") >= 1,
-        "get NotFound missing: {totals:?}"
+        has(&counts, "ginnungagap.v1.KvService/Put", "0"),
+        "kv Put Ok: {counts:?}"
     );
     assert!(
-        get("put", "InvalidArgument") >= 1,
-        "put InvalidArgument missing: {totals:?}"
+        has(&counts, "ginnungagap.v1.KvService/Get", "0"),
+        "kv Get Ok: {counts:?}"
     );
     assert!(
-        get("put", "Aborted") >= 1,
-        "put Aborted missing: {totals:?}"
+        has(&counts, "ginnungagap.v1.KvService/Get", "5"),
+        "kv Get NotFound: {counts:?}"
     );
-    assert!(get("delete", "Ok") >= 1, "delete Ok missing: {totals:?}");
-    assert!(get("scan", "Ok") >= 1, "scan Ok missing: {totals:?}");
     assert!(
-        get("compare_and_swap", "Ok") >= 1,
-        "cas Ok missing: {totals:?}"
+        has(&counts, "ginnungagap.v1.KvService/Put", "3"),
+        "kv Put InvalidArgument: {counts:?}"
+    );
+    assert!(
+        has(&counts, "ginnungagap.v1.KvService/Put", "10"),
+        "kv Put Aborted: {counts:?}"
+    );
+    assert!(
+        has(&counts, "ginnungagap.v1.KvService/Delete", "0"),
+        "kv Delete Ok: {counts:?}"
+    );
+    assert!(
+        has(&counts, "ginnungagap.v1.KvService/Scan", "0"),
+        "kv Scan Ok: {counts:?}"
+    );
+    assert!(
+        has(&counts, "ginnungagap.v1.KvService/CompareAndSwap", "0"),
+        "kv Cas Ok: {counts:?}"
     );
 
-    // Histogram must emit for every (method, status) pair the counter saw.
-    let hist = histogram_method_statuses(snap);
-    for key in totals.keys() {
-        assert!(
-            hist.iter().any(|(m, s)| m == &key.0 && s == &key.1),
-            "histogram missing {key:?}; saw {hist:?}",
-        );
-    }
+    // AdminService
+    assert!(
+        has(&counts, "ginnungagap.v1.AdminService/ClusterStatus", "0"),
+        "admin ClusterStatus Ok: {counts:?}"
+    );
+    assert!(
+        has(&counts, "ginnungagap.v1.AdminService/ListShards", "0"),
+        "admin ListShards Ok: {counts:?}"
+    );
+    assert!(
+        has(&counts, "ginnungagap.v1.AdminService/AddLearner", "3"),
+        "admin AddLearner InvalidArgument: {counts:?}"
+    );
+
+    // RaftService
+    assert!(
+        has(&counts, "ginnungagap.v1.RaftService/Vote", "5"),
+        "raft Vote NotFound: {counts:?}"
+    );
 
     node.raft.shutdown().await.ok();
     for h in node._handles {

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -70,8 +70,9 @@ grpcurl -plaintext -d '{"key":"aGVsbG8="}' \
   localhost:17000 ginnungagap.v1.KvService/Get
 ```
 
-The Grafana dashboard should show `ggap_kv_requests_total` climbing within
-~30 seconds (OTel scrape + Prometheus scrape intervals stacked).
+The Grafana dashboard should show
+`rpc_server_call_duration_seconds_count{rpc_method=~"ginnungagap.v1.KvService/.*"}`
+climbing within ~30 seconds (OTel scrape + Prometheus scrape intervals stacked).
 
 ## How cluster formation works
 

--- a/deploy/k8s/grafana/configmap-dashboards.yaml
+++ b/deploy/k8s/grafana/configmap-dashboards.yaml
@@ -37,8 +37,8 @@ data:
             {
               "refId": "A",
               "datasource": {"type": "prometheus", "uid": "prometheus"},
-              "expr": "sum by (method) (rate(ggap_kv_requests_total[1m]))",
-              "legendFormat": "{{method}}"
+              "expr": "sum by (rpc_method) (rate(rpc_server_call_duration_seconds_count{rpc_method=~\"ginnungagap\\\\.v1\\\\.KvService/.*\"}[1m]))",
+              "legendFormat": "{{rpc_method}}"
             }
           ],
           "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
@@ -53,7 +53,7 @@ data:
             {
               "refId": "A",
               "datasource": {"type": "prometheus", "uid": "prometheus"},
-              "expr": "sum by (pod) (rate(ggap_kv_requests_total[1m]))",
+              "expr": "sum by (pod) (rate(rpc_server_call_duration_seconds_count{rpc_method=~\"ginnungagap\\\\.v1\\\\.KvService/.*\"}[1m]))",
               "legendFormat": "{{pod}}"
             }
           ],
@@ -69,14 +69,14 @@ data:
             {
               "refId": "A",
               "datasource": {"type": "prometheus", "uid": "prometheus"},
-              "expr": "histogram_quantile(0.5, sum by (le, method) (rate(ggap_kv_request_duration_seconds_bucket[5m])))",
-              "legendFormat": "p50 {{method}}"
+              "expr": "histogram_quantile(0.5, sum by (le, rpc_method) (rate(rpc_server_call_duration_seconds_bucket{rpc_method=~\"ginnungagap\\\\.v1\\\\.KvService/.*\"}[5m])))",
+              "legendFormat": "p50 {{rpc_method}}"
             },
             {
               "refId": "B",
               "datasource": {"type": "prometheus", "uid": "prometheus"},
-              "expr": "histogram_quantile(0.99, sum by (le, method) (rate(ggap_kv_request_duration_seconds_bucket[5m])))",
-              "legendFormat": "p99 {{method}}"
+              "expr": "histogram_quantile(0.99, sum by (le, rpc_method) (rate(rpc_server_call_duration_seconds_bucket{rpc_method=~\"ginnungagap\\\\.v1\\\\.KvService/.*\"}[5m])))",
+              "legendFormat": "p99 {{rpc_method}}"
             }
           ],
           "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
@@ -91,8 +91,8 @@ data:
             {
               "refId": "A",
               "datasource": {"type": "prometheus", "uid": "prometheus"},
-              "expr": "sum by (method, status) (rate(ggap_kv_requests_total{status!=\"OK\"}[1m]))",
-              "legendFormat": "{{method}} / {{status}}"
+              "expr": "sum by (rpc_method, rpc_response_status_code) (rate(rpc_server_call_duration_seconds_count{rpc_method=~\"ginnungagap\\\\.v1\\\\.KvService/.*\", rpc_response_status_code!=\"0\"}[1m]))",
+              "legendFormat": "{{rpc_method}} / {{rpc_response_status_code}}"
             }
           ],
           "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},


### PR DESCRIPTION
Re-align the Prometheus request-latency instrumentation with the stabilized
OpenTelemetry RPC semantic conventions (`rpc.server.call.duration`) and
extend it to AdminService and RaftService, which were previously
uninstrumented. The single histogram `rpc_server_call_duration_seconds`
now carries:

  - rpc.system.name        = "grpc"
  - rpc.method             = "<package>.<Service>/<Method>"
  - rpc.response.status_code = <numeric gRPC code>

Request count is derived from the histogram's `_count`; the separate
`ggap_kv_requests_total` counter is dropped. Watch (streaming) is left
uninstrumented — session lifetime is not an RPC request duration.

Grafana dashboard PromQL and the deploy README prose are updated to the
new metric/label names. The test binary is renamed kv_metrics.rs ->
rpc_metrics.rs and now exercises all three services under one shared
DebuggingRecorder.

https://claude.ai/code/session_01SD7MfVwvdww27iPTduJPMo