### PR TITLE
chore: remove no-op --peer CLI flag

### DIFF
--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -37,9 +37,6 @@ struct Cli {
     client_addr: String,
     #[arg(long, default_value = "0.0.0.0:17001")]
     cluster_addr: String,
-    /// Peer specs: "id=addr" format, repeatable
-    #[arg(long = "peer")]
-    peers: Vec<String>,
     /// Initialize shard 0 as a fresh single-voter Raft cluster on first boot.
     /// Exactly one node in a fresh deployment should run with this flag; other
     /// nodes start uninitialized and wait for `AdminService.AddLearner` +

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - ggap/configmap.yaml
+  - tools/configmap.yaml
+  - tools/pod.yaml
   - ggap/service-headless.yaml
   - ggap/service-client.yaml
   - ggap/statefulset.yaml

--- a/deploy/k8s/tools/configmap.yaml
+++ b/deploy/k8s/tools/configmap.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ggap-tools-scripts
+  namespace: ginnungagap
+data:
+  # Print ClusterStatus from all three nodes side-by-side.
+  status: |
+    #!/bin/sh
+    for i in 0 1 2; do
+      addr="ggap-${i}.ggap-headless.ginnungagap.svc.cluster.local:17001"
+      printf '\n=== ggap-%s ===\n' "$i"
+      grpcurl -plaintext -max-time 3 "$addr" \
+        ginnungagap.v1.AdminService/ClusterStatus 2>&1 || true
+    done
+
+  # Resolve the current leader and print its client address (host:17000).
+  # Exit 1 if no leader is elected yet.
+  leader: |
+    #!/bin/sh
+    SEED="ggap-0.ggap-headless.ginnungagap.svc.cluster.local:17001"
+    STATUS=$(grpcurl -plaintext -max-time 5 "$SEED" \
+               ginnungagap.v1.AdminService/ClusterStatus 2>&1)
+    LEADER_ID=$(printf '%s' "$STATUS" | grep '"leaderId"' | grep -o '[0-9]*' | head -1)
+    if [ -z "$LEADER_ID" ]; then
+      printf 'no leader elected yet\n%s\n' "$STATUS" >&2
+      exit 1
+    fi
+    ORDINAL=$((LEADER_ID - 1))
+    echo "ggap-${ORDINAL}.ggap-headless.ginnungagap.svc.cluster.local:17000"
+
+  # Store a UTF-8 value.  Usage: put <key> <value>
+  # gRPC bytes fields are base64 in JSON; this script encodes the value.
+  put: |
+    #!/bin/sh
+    if [ $# -lt 2 ]; then
+      echo "usage: put <key> <value>" >&2
+      exit 1
+    fi
+    KEY="$1"; VALUE="$2"
+    LEADER=$(leader)
+    VALUE_B64=$(printf '%s' "$VALUE" | base64 | tr -d '\n')
+    grpcurl -plaintext \
+      -d "{\"key\":\"${KEY}\",\"value\":\"${VALUE_B64}\"}" \
+      "$LEADER" ginnungagap.v1.KvService/Put
+
+  # Fetch a key and decode the bytes value back to a string.
+  # Usage: get <key> [linearizable|sequential|eventual]
+  get: |
+    #!/bin/sh
+    if [ $# -lt 1 ]; then
+      echo "usage: get <key> [linearizable|sequential|eventual]" >&2
+      exit 1
+    fi
+    KEY="$1"
+    CONSISTENCY="${2:-LINEARIZABLE}"
+    LEADER=$(leader)
+    RESP=$(grpcurl -plaintext \
+             -d "{\"key\":\"${KEY}\",\"consistency\":\"${CONSISTENCY}\"}" \
+             "$LEADER" ginnungagap.v1.KvService/Get)
+    echo "$RESP"
+    # Decode the raw bytes value for readability.
+    RAW=$(printf '%s' "$RESP" | grep '"value"' | sed 's/.*"value": "\([^"]*\)".*/\1/')
+    if [ -n "$RAW" ]; then
+      printf 'decoded value: %s\n' "$(printf '%s' "$RAW" | base64 -d 2>/dev/null)"
+    fi
+
+  # Scan a key range.  Usage: scan <start-key> <end-key> [limit]
+  scan: |
+    #!/bin/sh
+    if [ $# -lt 2 ]; then
+      echo "usage: scan <start-key> <end-key> [limit]" >&2
+      exit 1
+    fi
+    START="$1"; END="$2"; LIMIT="${3:-100}"
+    LEADER=$(leader)
+    grpcurl -plaintext \
+      -d "{\"startKey\":\"${START}\",\"endKey\":\"${END}\",\"limit\":${LIMIT}}" \
+      "$LEADER" ginnungagap.v1.KvService/Scan
+
+  # Delete a key.  Usage: del <key>
+  del: |
+    #!/bin/sh
+    if [ $# -lt 1 ]; then
+      echo "usage: del <key>" >&2
+      exit 1
+    fi
+    KEY="$1"
+    LEADER=$(leader)
+    grpcurl -plaintext \
+      -d "{\"key\":\"${KEY}\"}" \
+      "$LEADER" ginnungagap.v1.KvService/Delete

--- a/deploy/k8s/tools/pod.yaml
+++ b/deploy/k8s/tools/pod.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ggap-tools
+  namespace: ginnungagap
+  labels:
+    app.kubernetes.io/name: ggap-tools
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ggap-tools
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ggap-tools
+    spec:
+      containers:
+        - name: tools
+          # Same image as the bootstrap job: grpcurl + Alpine shell.
+          image: fullstorydev/grpcurl:v1.9.1-alpine
+          command: ["sh", "-c", "while true; do sleep 3600; done"]
+          env:
+            - name: PATH
+              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/scripts
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 200m
+              memory: 64Mi
+      volumes:
+        - name: scripts
+          configMap:
+            name: ggap-tools-scripts
+            defaultMode: 0555


### PR DESCRIPTION
## Summary

- Remove no-op `--peer` CLI flag — `peers: Vec<String>` was parsed by clap but never read. Cluster membership is managed via `--seed` on first boot and `AdminService.AddLearner` / `ChangeMembership` RPCs thereafter.
- Add `deploy/k8s/tools/` — a long-running Alpine/grpcurl debug pod with shell scripts mounted from a ConfigMap for quick cluster inspection from inside the cluster: `status`, `leader`, `put`, `get`, `scan`, `del`.

## Test plan

- [x] `cargo fmt`, `cargo clippy`, `cargo build`, `cargo test` all pass
- [ ] Deploy `ggap-tools` pod and verify scripts reach the cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)