### PR TITLE
fix: stable DNS peer advertisement and --cluster-listen-addr

### DIFF
--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -37,6 +37,11 @@ struct Cli {
     client_addr: String,
     #[arg(long, default_value = "0.0.0.0:17001")]
     cluster_addr: String,
+    /// Address to bind the cluster gRPC listener to. Defaults to `--cluster-addr`
+    /// when omitted. Set this to `0.0.0.0:<port>` when `--cluster-addr` is a DNS
+    /// hostname that should only be used for Raft peer advertisement.
+    #[arg(long)]
+    cluster_listen_addr: Option<String>,
     /// Initialize shard 0 as a fresh single-voter Raft cluster on first boot.
     /// Exactly one node in a fresh deployment should run with this flag; other
     /// nodes start uninitialized and wait for `AdminService.AddLearner` +
@@ -157,10 +162,16 @@ async fn main() -> anyhow::Result<()> {
         .client_addr
         .parse()
         .with_context(|| format!("invalid client_addr: {}", cli.client_addr))?;
-    let cluster_addr: SocketAddr = cli
-        .cluster_addr
-        .parse()
-        .with_context(|| format!("invalid cluster_addr: {}", cli.cluster_addr))?;
+    let cluster_addr: SocketAddr = match &cli.cluster_listen_addr {
+        Some(listen) => listen
+            .parse()
+            .with_context(|| format!("invalid cluster_listen_addr: {listen}"))?,
+        None => tokio::net::lookup_host(&cli.cluster_addr)
+            .await
+            .with_context(|| format!("cannot resolve cluster_addr: {}", cli.cluster_addr))?
+            .next()
+            .with_context(|| format!("no addresses for cluster_addr: {}", cli.cluster_addr))?,
+    };
 
     // Use data_dir from CLI if provided (non-default), else fall back to config.
     let data_dir = if cli.data_dir == std::path::Path::new("/var/lib/ginnungagap") {
@@ -253,7 +264,7 @@ async fn main() -> anyhow::Result<()> {
                 Ok(None) if cli.seed => Some(BTreeMap::from([(
                     cli.node_id,
                     BasicNode {
-                        addr: cluster_addr.to_string(),
+                        addr: cli.cluster_addr.clone(),
                     },
                 )])),
                 Ok(None) => None,

--- a/deploy/k8s/bootstrap/job.yaml
+++ b/deploy/k8s/bootstrap/job.yaml
@@ -16,7 +16,7 @@ data:
     # Idempotent: if ClusterStatus already reports >= 3 voters, exits 0.
     set -eu
 
-    SEED=ggap-0.ggap-headless.ginnungagap.svc.cluster.local:17001
+    SEED=ggap-2.ggap-headless.ginnungagap.svc.cluster.local:17001
 
     echo "waiting for seed AdminService at ${SEED}..."
     i=0
@@ -43,7 +43,7 @@ data:
       exit 0
     fi
 
-    for id in 2 3; do
+    for id in 1 2; do
       ord=$((id - 1))
       addr="ggap-${ord}.ggap-headless.ginnungagap.svc.cluster.local:17001"
       echo "AddLearner node_id=${id} cluster_addr=${addr}"

--- a/deploy/k8s/ggap/configmap.yaml
+++ b/deploy/k8s/ggap/configmap.yaml
@@ -14,17 +14,14 @@ data:
     # ordinals 1 and 2 into voters. Restarts are no-ops because ggap-node
     # checks raft.is_initialized() before re-initializing.
     SEED_FLAG=""
-    if [ "${ORDINAL}" = "0" ]; then
+    if [ "${ORDINAL}" = "2" ]; then
       SEED_FLAG="--seed"
     fi
     echo "ggap-node starting: node_id=${NODE_ID} seed=${SEED_FLAG:-no}"
     exec /usr/local/bin/ggap-node \
       --node-id "${NODE_ID}" \
       --client-addr 0.0.0.0:17000 \
-      --cluster-addr $( hostname -i ):17001 \
+      --cluster-addr ggap-${ORDINAL}.ggap-headless.ginnungagap.svc.cluster.local:17001 \
       --data-dir /var/lib/ginnungagap \
       --metrics-addr 0.0.0.0:9090 \
-      ${SEED_FLAG} \
-      --peer 1=ggap-0.ggap-headless.ginnungagap.svc.cluster.local:17001 \
-      --peer 2=ggap-1.ggap-headless.ginnungagap.svc.cluster.local:17001 \
-      --peer 3=ggap-2.ggap-headless.ginnungagap.svc.cluster.local:17001
+      ${SEED_FLAG}


### PR DESCRIPTION
## Summary

- **Root cause:** the seed node registered its ephemeral pod IP (`hostname -i`) as its Raft cluster address. After a pod restart the IP changes but the persisted membership still has the old one, causing indefinite `AppendEntries` timeouts from any subsequent leader.
- **Fix:** `--cluster-addr` is now stored verbatim in `BasicNode.addr` (Raft advertisement) and resolved via `lookup_host` only for the bind `SocketAddr`. Passing a stable headless-service DNS name (`ggap-${ORDINAL}.ggap-headless…:17001`) makes the advertised address survive pod restarts.
- **New flag:** `--cluster-listen-addr` (optional) lets the bind address differ from the advertised address — useful when you want to bind `0.0.0.0:17001` but advertise the DNS hostname.
- **Bootstrap alignment:** seed moved to `ggap-2` (node_id=3); `AddLearner` loop updated to cover node_ids 1 and 2.

## Test plan

- [ ] Fresh 3-node deploy: all nodes reach steady state, no AppendEntries timeout logs
- [ ] Kill and restart `ggap-2` pod; verify the new leader continues replicating to it without timeout
- [ ] Verify `--cluster-listen-addr 0.0.0.0:17001` works when set explicitly
- [ ] Existing unit and integration tests pass (`cargo test --all`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)