### PR TITLE
Implement cross-shard scan with continuation tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ dependencies = [
 name = "ggap-types"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "bytes",
  "serde",
  "thiserror",

--- a/crates/ggap-consensus/src/router.rs
+++ b/crates/ggap-consensus/src/router.rs
@@ -85,13 +85,15 @@ impl ShardRouter {
             })
     }
 
-    /// Look up the RaftNode for a scan operation.
-    /// For correctness, the entire scan range must be within a single shard.
-    pub async fn route_scan(
-        &self,
-        start_key: &str,
-        end_key: &str,
-    ) -> Result<Arc<OpenRaftNode>, GgapError> {
+    /// Look up the RaftNode that owns `start_key`.
+    ///
+    /// Cross-shard scans are allowed: the service layer is responsible for
+    /// bounding each per-shard scan call to the owning shard's `range.end`
+    /// and advancing the cursor across shards via continuation tokens.
+    /// `Splitting` shards still serve scans — a cursor that lands in a
+    /// post-split child shard on the next RPC is routed naturally by
+    /// `lookup_shard(next_key)`.
+    pub async fn route_scan(&self, start_key: &str) -> Result<Arc<OpenRaftNode>, GgapError> {
         let info = self
             .shard_map
             .lookup_shard(start_key)
@@ -99,17 +101,6 @@ impl ShardRouter {
             .ok_or_else(|| {
                 GgapError::InvalidArgument(format!("no shard found for key '{start_key}'"))
             })?;
-
-        // If end_key is specified and falls outside this shard's range, reject
-        if !end_key.is_empty() && !info.range.contains(end_key) {
-            // Check that end_key is at most the shard boundary
-            // (end_key == shard.range.end is acceptable as an exclusive bound)
-            if !info.range.end.is_empty() && end_key > info.range.end.as_str() {
-                return Err(GgapError::InvalidArgument(
-                    "scan range spans multiple shards".into(),
-                ));
-            }
-        }
 
         let nodes = self.nodes.read().await;
         nodes

--- a/crates/ggap-server/src/kv_service.rs
+++ b/crates/ggap-server/src/kv_service.rs
@@ -7,7 +7,7 @@ use ggap_proto::v1::{
     DeleteResponse, EventType, GetRequest, GetResponse, PutRequest, PutResponse, ScanRequest,
     ScanResponse, WatchEvent, WatchRequest,
 };
-use ggap_types::{DomainWatchEvent, KvCommand, WatchEventKind};
+use ggap_types::{DomainWatchEvent, KvCommand, KvEntry, ScanContinuation, WatchEventKind};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 
@@ -21,6 +21,22 @@ static NEXT_WATCH_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Maximum scan limit to prevent resource exhaustion from unbounded scans.
 const MAX_SCAN_LIMIT: u32 = 10_000;
+
+/// Maximum number of shards a single Scan RPC may hop across while looking
+/// for matching keys. Bounds tail latency on sparse keyspaces while still
+/// auto-skipping empty middle shards so clients don't pay one round-trip
+/// per empty shard.
+const MAX_SCAN_HOPS_PER_RPC: u32 = 8;
+
+/// Returns the more restrictive non-empty exclusive end bound, or empty if
+/// both are empty (unbounded).
+fn tighter_end(a: &str, b: &str) -> String {
+    match (a.is_empty(), b.is_empty()) {
+        (true, _) => b.to_string(),
+        (_, true) => a.to_string(),
+        _ => a.min(b).to_string(),
+    }
+}
 
 pub struct KvServiceImpl {
     router: Arc<ShardRouter>,
@@ -144,11 +160,13 @@ impl KvServiceImpl {
     }
 
     async fn do_scan(&self, req: ScanRequest) -> Result<Response<ScanResponse>, Status> {
-        let start_key = if req.page_token.is_empty() {
+        // page_token is an opaque ScanContinuation. Empty ⇒ first page.
+        let initial_start = if req.page_token.is_empty() {
             req.start_key.clone()
         } else {
-            String::from_utf8(req.page_token.to_vec())
-                .map_err(|_| Status::invalid_argument("invalid page_token: not valid UTF-8"))?
+            ScanContinuation::decode(&req.page_token)
+                .map_err(ggap_to_status)?
+                .next_key
         };
         let mode = proto_read_consistency(req.consistency);
         let limit = if req.limit == 0 {
@@ -156,18 +174,131 @@ impl KvServiceImpl {
         } else {
             req.limit.min(MAX_SCAN_LIMIT)
         };
-        let node = self
-            .router
-            .route_scan(&start_key, &req.end_key)
-            .await
-            .map_err(ggap_to_status)?;
-        let (entries, continuation) = node
-            .scan(&start_key, &req.end_key, limit, mode)
-            .await
-            .map_err(ggap_to_status)?;
+        let req_end = req.end_key.clone();
 
-        let kvs = entries.into_iter().map(kv_entry_to_proto).collect();
-        let next_page_token = continuation.map(|k| k.into_bytes()).unwrap_or_default();
+        let mut all_kvs: Vec<KvEntry> = Vec::new();
+        let mut cursor = initial_start;
+        let mut remaining = limit;
+        // None ⇒ caller has fully consumed the scan range. Some(blob) ⇒
+        // more remains; client must pass it back.
+        let mut next_token: Option<Vec<u8>> = None;
+
+        for _hop in 0..MAX_SCAN_HOPS_PER_RPC {
+            // Resolve the shard owning `cursor`. Routing by key always lands
+            // on the correct shard even if a split committed since the token
+            // was issued. Linearizable mode is enforced per shard inside
+            // `node.scan`; cross-shard scans are NOT snapshot-isolated.
+            let node = self
+                .router
+                .route_scan(&cursor)
+                .await
+                .map_err(ggap_to_status)?;
+            let shard = self
+                .router
+                .shard_map()
+                .lookup_shard(&cursor)
+                .await
+                .ok_or_else(|| {
+                    Status::failed_precondition(format!("no shard for cursor '{cursor}'"))
+                })?;
+            let effective_end = tighter_end(&shard.range.end, &req_end);
+
+            let (entries, continuation) = node
+                .scan(&cursor, &effective_end, remaining, mode)
+                .await
+                .map_err(ggap_to_status)?;
+
+            let got = entries.len() as u32;
+            all_kvs.extend(entries);
+            remaining = remaining.saturating_sub(got);
+
+            if let Some(k) = continuation {
+                // Limit hit inside this shard; resume here next RPC.
+                next_token = Some(
+                    ScanContinuation {
+                        next_key: k,
+                        shard_id_hint: shard.shard_id,
+                    }
+                    .encode()
+                    .map_err(ggap_to_status)?,
+                );
+                break;
+            }
+
+            // Shard exhausted. Decide whether to stop or hop forward.
+            let last_shard = shard.range.end.is_empty();
+            let request_done =
+                !req_end.is_empty() && (last_shard || shard.range.end.as_str() >= req_end.as_str());
+            if last_shard || request_done || remaining == 0 {
+                // Truly done; leave next_token as None.
+                break;
+            }
+
+            // More shards remain in the requested range. Advance cursor to
+            // this shard's end (= start of the next contiguous shard).
+            cursor = shard.range.end.clone();
+
+            if !all_kvs.is_empty() {
+                // We already have data — surface it. Encode a token at the
+                // boundary so the client picks up at the next shard.
+                let hint = self
+                    .router
+                    .shard_map()
+                    .lookup_shard(&cursor)
+                    .await
+                    .map(|s| s.shard_id)
+                    .unwrap_or(shard.shard_id);
+                next_token = Some(
+                    ScanContinuation {
+                        next_key: cursor.clone(),
+                        shard_id_hint: hint,
+                    }
+                    .encode()
+                    .map_err(ggap_to_status)?,
+                );
+                break;
+            }
+            // No results yet; auto-hop into the next shard (bounded by
+            // MAX_SCAN_HOPS_PER_RPC) so a sparse keyspace doesn't force
+            // the client into a token ping-pong of empty pages.
+        }
+
+        // If we exited the loop with no results AND no break-emitted token,
+        // it means we exhausted MAX_SCAN_HOPS_PER_RPC. Surface progress so
+        // the client can resume — otherwise scanning a sparse keyspace
+        // larger than the hop budget would silently look "done".
+        if next_token.is_none() && all_kvs.is_empty() && remaining == limit {
+            // remaining == limit ⇒ we never returned even one entry.
+            // Re-check whether cursor still has range left.
+            let cursor_in_range = req_end.is_empty() || cursor.as_str() < req_end.as_str();
+            if cursor_in_range
+                && self
+                    .router
+                    .shard_map()
+                    .lookup_shard(&cursor)
+                    .await
+                    .is_some()
+            {
+                let hint = self
+                    .router
+                    .shard_map()
+                    .lookup_shard(&cursor)
+                    .await
+                    .map(|s| s.shard_id)
+                    .unwrap_or(0);
+                next_token = Some(
+                    ScanContinuation {
+                        next_key: cursor,
+                        shard_id_hint: hint,
+                    }
+                    .encode()
+                    .map_err(ggap_to_status)?,
+                );
+            }
+        }
+
+        let kvs = all_kvs.into_iter().map(kv_entry_to_proto).collect();
+        let next_page_token = next_token.unwrap_or_default();
 
         Ok(Response::new(ScanResponse {
             header: Some(stub_header(self.node_id)),

--- a/crates/ggap-server/src/lib.rs
+++ b/crates/ggap-server/src/lib.rs
@@ -24,6 +24,10 @@ use kv_service::KvServiceImpl;
 use raft_service::RaftServiceImpl;
 use tracing_layer::OtelServerLayer;
 
+// Re-exported so integration tests can construct the service and exercise
+// cross-shard scan hopping without spinning up a real gRPC server.
+pub use kv_service::KvServiceImpl as KvServiceForTesting;
+
 /// Configuration for the client-facing KV service.
 #[derive(Clone, Debug)]
 pub struct KvServiceConfig {

--- a/crates/ggap-server/tests/cross_shard_scan.rs
+++ b/crates/ggap-server/tests/cross_shard_scan.rs
@@ -1,0 +1,362 @@
+//! Cross-shard scan integration tests.
+//!
+//! Exercises `KvServiceImpl::do_scan`'s cross-shard hop logic and the
+//! `ScanContinuation` token round-trip via the public `KvService` trait.
+//!
+//! Run with:
+//!   cargo test -p ggap-server --test cross_shard_scan -- --nocapture
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::{BasicNode, ServerState};
+use tempfile::TempDir;
+use tonic::Request;
+
+use ggap_consensus::{
+    build_raft_config, run_split_handler, GgapLogStorage, GgapNetworkFactory, GgapRaft,
+    GgapStateMachine, OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator,
+    SplitCoordinatorConfig,
+};
+use ggap_proto::v1::{kv_service_server::KvService, ScanRequest};
+use ggap_server::{KvServiceConfig, KvServiceForTesting};
+use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
+use ggap_storage::ShardMap;
+use ggap_types::{KvCommand, ScanContinuation};
+
+struct TestSetup {
+    router: Arc<ShardRouter>,
+    split_coordinator: Arc<SplitCoordinator>,
+    raft: Arc<GgapRaft>,
+    service: KvServiceForTesting,
+    _tempdir: TempDir,
+}
+
+async fn setup() -> TestSetup {
+    let tempdir = TempDir::new().unwrap();
+    let store = FjallStore::open(tempdir.path()).unwrap();
+
+    let shard_map = Arc::new(ShardMap::load(store.clone()).unwrap());
+    shard_map.initialize_default().await.unwrap();
+
+    let (split_tx, split_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let mut fsm_builder = FjallStateMachine::new(store.clone());
+    fsm_builder.set_split_sender(split_tx);
+    fsm_builder.set_shard_map(shard_map.clone());
+    let fsm = Arc::new(fsm_builder);
+
+    let raft_cfg = build_raft_config(50, 150, 300, 500);
+    let log_store = GgapLogStorage::new(FjallLogStorage(store.clone()), 0);
+    let sm = GgapStateMachine::new(fsm.clone(), 0);
+    let raft = Arc::new(
+        GgapRaft::new(
+            1,
+            raft_cfg.clone(),
+            GgapNetworkFactory::new(0),
+            log_store,
+            sm,
+        )
+        .await
+        .unwrap(),
+    );
+
+    let mut members = BTreeMap::new();
+    members.insert(1u64, BasicNode::default());
+    raft.initialize(members).await.unwrap();
+    raft.wait(Some(Duration::from_secs(5)))
+        .state(ServerState::Leader, "become leader")
+        .await
+        .unwrap();
+
+    let router = Arc::new(ShardRouter::new(shard_map.clone()));
+    let node = Arc::new(OpenRaftNode::new(
+        raft.clone(),
+        fsm.clone(),
+        0,
+        1,
+        tokio::time::Duration::from_millis(100),
+    ));
+    let cluster = Arc::new(OpenRaftCluster::new(raft.clone()));
+    router.add_shard(0, node, cluster).await;
+
+    tokio::spawn(run_split_handler(
+        split_rx,
+        store.clone(),
+        fsm.clone(),
+        router.clone(),
+        1,
+        raft_cfg,
+    ));
+
+    let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
+        router: router.clone(),
+        shard_map: shard_map.clone(),
+    }));
+
+    let cfg = KvServiceConfig::default();
+    let service = KvServiceForTesting::new(
+        router.clone(),
+        1,
+        cfg.max_key_bytes,
+        cfg.max_value_bytes,
+        cfg.watch_tx,
+        cfg.watch_output_buffer,
+    );
+
+    TestSetup {
+        router,
+        split_coordinator,
+        raft,
+        service,
+        _tempdir: tempdir,
+    }
+}
+
+async fn put(s: &TestSetup, key: &str) {
+    s.raft
+        .client_write(KvCommand::Put {
+            key: key.into(),
+            value: key.as_bytes().to_vec(),
+            ttl_ns: None,
+            expect_version: 0,
+        })
+        .await
+        .unwrap();
+}
+
+/// Drives `do_scan` to completion, returning all keys observed and how many
+/// RPCs it took. Each call uses the supplied `limit`.
+async fn drain(
+    service: &KvServiceForTesting,
+    start_key: &str,
+    end_key: &str,
+    limit: u32,
+) -> (Vec<String>, usize) {
+    let mut keys = Vec::new();
+    let mut token: Vec<u8> = Vec::new();
+    let mut rpcs = 0usize;
+    loop {
+        rpcs += 1;
+        assert!(rpcs < 200, "drain runaway after {rpcs} RPCs");
+        let req = ScanRequest {
+            start_key: if token.is_empty() {
+                start_key.into()
+            } else {
+                String::new()
+            },
+            end_key: end_key.into(),
+            limit,
+            page_token: token.clone(),
+            consistency: 0,
+        };
+        let resp = service.scan(Request::new(req)).await.unwrap().into_inner();
+        for kv in resp.kvs {
+            keys.push(kv.key);
+        }
+        if resp.next_page_token.is_empty() {
+            break;
+        }
+        token = resp.next_page_token;
+    }
+    (keys, rpcs)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_spans_two_shards() {
+    let s = setup().await;
+
+    let written: Vec<&str> = vec!["a", "c", "e", "g", "m", "o", "q", "s", "u", "y"];
+    for k in &written {
+        put(&s, k).await;
+    }
+    s.split_coordinator.split(0, "m").await.unwrap();
+    assert_eq!(s.router.shard_map().all_shards().await.len(), 2);
+
+    // Small limit forces multiple hops, exercising token round-trip across
+    // the shard boundary at "m".
+    let (keys, rpcs) = drain(&s.service, "", "", 3).await;
+    assert_eq!(keys, written);
+    assert!(rpcs >= 4, "expected paginated walk, got {rpcs} rpcs");
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_spans_three_shards_with_empty_middle() {
+    let s = setup().await;
+
+    // Write only into ranges ["a", "m") and ["s", "z").
+    for k in &["a", "c", "e", "g"] {
+        put(&s, k).await;
+    }
+    for k in &["s", "u", "y"] {
+        put(&s, k).await;
+    }
+
+    // Two splits: ["", "m"), ["m", "s"), ["s", "")
+    s.split_coordinator.split(0, "m").await.unwrap();
+    s.split_coordinator.split(1, "s").await.unwrap();
+    assert_eq!(s.router.shard_map().all_shards().await.len(), 3);
+
+    // Drain the scan; verify all keys observed and that the empty middle
+    // shard was auto-hopped server-side (i.e. no RPC returns zero rows
+    // until the scan is complete).
+    let (keys, rpcs) = drain(&s.service, "", "", 100).await;
+    assert_eq!(keys, vec!["a", "c", "e", "g", "s", "u", "y"]);
+    // Expected hops: RPC 1 returns shard 0 contents + token at "m"; RPC 2
+    // auto-skips empty shard 1, drains shard 2, returns no token. So <= 2
+    // data-bearing RPCs. We do NOT want one RPC per shard.
+    assert!(rpcs <= 2, "expected at most 2 RPCs, got {rpcs}");
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_auto_hops_leading_empty_shards() {
+    let s = setup().await;
+
+    // Write only into the last shard's future range.
+    for k in &["s", "u", "y"] {
+        put(&s, k).await;
+    }
+    // Split: ["", "m"), ["m", "s"), ["s", "")
+    s.split_coordinator.split(0, "m").await.unwrap();
+    s.split_coordinator.split(1, "s").await.unwrap();
+    assert_eq!(s.router.shard_map().all_shards().await.len(), 3);
+
+    // The first two shards are empty. A single RPC should hop through them
+    // and surface the data from shard 2 — exactly the case auto-hop is
+    // intended to handle (no token ping-pong on a sparse keyspace).
+    let req = ScanRequest {
+        start_key: String::new(),
+        end_key: String::new(),
+        limit: 100,
+        page_token: Vec::new(),
+        consistency: 0,
+    };
+    let resp = s
+        .service
+        .scan(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner();
+    let observed: Vec<String> = resp.kvs.into_iter().map(|k| k.key).collect();
+    assert_eq!(observed, vec!["s", "u", "y"]);
+    assert!(
+        resp.next_page_token.is_empty(),
+        "expected scan to finish in one RPC"
+    );
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_token_after_intervening_split() {
+    let s = setup().await;
+
+    for k in &["a", "c", "e", "g", "m", "o", "q", "s", "u", "y"] {
+        put(&s, k).await;
+    }
+
+    // Page 1: limit=3, no split yet.
+    let req = ScanRequest {
+        start_key: String::new(),
+        end_key: String::new(),
+        limit: 3,
+        page_token: Vec::new(),
+        consistency: 0,
+    };
+    let resp = s
+        .service
+        .scan(Request::new(req))
+        .await
+        .unwrap()
+        .into_inner();
+    let page1: Vec<String> = resp.kvs.into_iter().map(|k| k.key).collect();
+    assert_eq!(page1, vec!["a", "c", "e"]);
+    let token = resp.next_page_token;
+    assert!(!token.is_empty());
+
+    // Token routes by key, not by shard id; after split the same next_key
+    // still resolves correctly.
+    let decoded = ScanContinuation::decode(&token).unwrap();
+    assert_eq!(decoded.next_key, "g");
+
+    // Split while client is mid-scan.
+    s.split_coordinator.split(0, "m").await.unwrap();
+
+    // Resume — drive remaining pages with small limit to force more hops
+    // across the new boundary.
+    let mut all = page1;
+    let mut tok = token;
+    loop {
+        let req = ScanRequest {
+            start_key: String::new(),
+            end_key: String::new(),
+            limit: 3,
+            page_token: tok.clone(),
+            consistency: 0,
+        };
+        let resp = s
+            .service
+            .scan(Request::new(req))
+            .await
+            .unwrap()
+            .into_inner();
+        for k in resp.kvs {
+            all.push(k.key);
+        }
+        if resp.next_page_token.is_empty() {
+            break;
+        }
+        tok = resp.next_page_token;
+    }
+
+    // At-least-once: every originally-written key is observed. Duplicates
+    // are permitted on the split boundary (none expected here because the
+    // split atomically moved keys in the Raft log).
+    let mut sorted = all.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(
+        sorted,
+        vec!["a", "c", "e", "g", "m", "o", "q", "s", "u", "y"]
+    );
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_with_invalid_page_token_rejected() {
+    let s = setup().await;
+
+    let req = ScanRequest {
+        start_key: String::new(),
+        end_key: String::new(),
+        limit: 10,
+        page_token: vec![0xff, 0xff, 0xff],
+        consistency: 0,
+    };
+    let err = s.service.scan(Request::new(req)).await.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    s.raft.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scan_respects_end_key_across_shards() {
+    let s = setup().await;
+
+    for k in &["a", "c", "m", "o", "u", "y"] {
+        put(&s, k).await;
+    }
+    s.split_coordinator.split(0, "m").await.unwrap();
+
+    // end_key = "p" sits inside shard 1; scan must stop at "p".
+    let (keys, _rpcs) = drain(&s.service, "", "p", 100).await;
+    assert_eq!(keys, vec!["a", "c", "m", "o"]);
+
+    s.raft.shutdown().await.unwrap();
+}

--- a/crates/ggap-server/tests/split_single_node.rs
+++ b/crates/ggap-server/tests/split_single_node.rs
@@ -356,14 +356,14 @@ async fn scan_within_shard_works_after_split() {
     s.split_coordinator.split(0, "m").await.unwrap();
 
     // Scan within shard 0 (keys < "m").
-    let node0 = s.router.route_scan("a", "m").await.unwrap();
+    let node0 = s.router.route_scan("a").await.unwrap();
     assert_eq!(node0.shard_id(), 0);
     let (entries, _) = node0.scan("a", "m", 100, ReadMode::Eventual).await.unwrap();
     let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
     assert_eq!(keys, vec!["a", "b", "c"]);
 
     // Scan within shard 1 (keys >= "m").
-    let node1 = s.router.route_scan("m", "").await.unwrap();
+    let node1 = s.router.route_scan("m").await.unwrap();
     assert_eq!(node1.shard_id(), 1);
     let (entries, _) = node1.scan("m", "", 100, ReadMode::Eventual).await.unwrap();
     let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();

--- a/crates/ggap-storage/src/shard_map.rs
+++ b/crates/ggap-storage/src/shard_map.rs
@@ -115,6 +115,22 @@ impl ShardMap {
         self.shards.read().await.values().cloned().collect()
     }
 
+    /// Return the shard whose `range.start` is strictly greater than `key`,
+    /// i.e. the shard that begins after `key`. Returns `None` if no shard
+    /// starts after `key` (i.e. `key` is at or past the last shard's start).
+    ///
+    /// Used to advance a cross-shard scan cursor when one shard is exhausted
+    /// and the scan still has range remaining. O(N) over shards; fine at the
+    /// current scale.
+    pub async fn next_shard_after(&self, key: &str) -> Option<ShardInfo> {
+        let shards = self.shards.read().await;
+        shards
+            .values()
+            .filter(|s| s.range.start.as_str() > key)
+            .min_by(|a, b| a.range.start.cmp(&b.range.start))
+            .cloned()
+    }
+
     /// Allocate the next shard_id (max existing + 1).
     pub async fn next_shard_id(&self) -> ShardId {
         let shards = self.shards.read().await;
@@ -227,6 +243,50 @@ mod tests {
         assert_eq!(map.next_shard_id().await, 0);
         map.initialize_default().await.unwrap();
         assert_eq!(map.next_shard_id().await, 1);
+    }
+
+    #[tokio::test]
+    async fn next_shard_after_empty_map_returns_none() {
+        let (_dir, store) = open_store();
+        let map = ShardMap::load(store).unwrap();
+        assert!(map.next_shard_after("anything").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn next_shard_after_traversal() {
+        let (_dir, store) = open_store();
+        let map = ShardMap::load(store).unwrap();
+
+        // Three shards: ["", "m"), ["m", "s"), ["s", "")
+        for (id, start, end) in [(0u64, "", "m"), (1, "m", "s"), (2, "s", "")] {
+            map.put_shard(ShardInfo {
+                shard_id: id,
+                range: KeyRange {
+                    start: start.into(),
+                    end: end.into(),
+                },
+                state: ShardState::Active,
+            })
+            .await
+            .unwrap();
+        }
+
+        // Key before the first shard's start ("") still returns the first
+        // shard whose start is strictly > key. Only shards with start > ""
+        // are eligible — so we get shard 1 (start "m").
+        let s = map.next_shard_after("").await.unwrap();
+        assert_eq!(s.shard_id, 1);
+
+        // Key inside shard 0 → next shard is shard 1.
+        let s = map.next_shard_after("a").await.unwrap();
+        assert_eq!(s.shard_id, 1);
+
+        // Key inside shard 1 → next shard is shard 2.
+        let s = map.next_shard_after("n").await.unwrap();
+        assert_eq!(s.shard_id, 2);
+
+        // Key inside shard 2 → no following shard.
+        assert!(map.next_shard_after("zebra").await.is_none());
     }
 
     #[test]

--- a/crates/ggap-types/Cargo.toml
+++ b/crates/ggap-types/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 thiserror = { workspace = true }
 serde = { workspace = true }
 bytes = { workspace = true }
+bincode = { workspace = true }

--- a/crates/ggap-types/src/lib.rs
+++ b/crates/ggap-types/src/lib.rs
@@ -203,3 +203,68 @@ pub enum GgapError {
     #[error("shard not found: {0}")]
     ShardNotFound(ShardId),
 }
+
+// ---------------------------------------------------------------------------
+// Scan continuation token
+// ---------------------------------------------------------------------------
+
+/// Opaque cursor returned in `ScanResponse.next_page_token`. Clients must
+/// pass it back unmodified; the structure is not stable across server
+/// versions. Cross-shard scans hop server-side and encode the next key
+/// (plus a shard hint) here.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ScanContinuation {
+    /// Inclusive start key for the next page.
+    pub next_key: String,
+    /// Shard the cursor was last positioned in. Informational; the router
+    /// resolves the actual owning shard from `next_key` on each request, so
+    /// this remains correct even if a split changes the boundary.
+    pub shard_id_hint: ShardId,
+}
+
+impl ScanContinuation {
+    pub fn encode(&self) -> Result<Vec<u8>, GgapError> {
+        bincode::serde::encode_to_vec(self, bincode::config::standard())
+            .map_err(|e| GgapError::InvalidArgument(format!("encode page_token: {e}")))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, GgapError> {
+        bincode::serde::decode_from_slice(bytes, bincode::config::standard())
+            .map(|(v, _)| v)
+            .map_err(|_| GgapError::InvalidArgument("invalid page_token".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_continuation_roundtrip() {
+        let c = ScanContinuation {
+            next_key: "hello".into(),
+            shard_id_hint: 7,
+        };
+        let bytes = c.encode().unwrap();
+        let back = ScanContinuation::decode(&bytes).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn scan_continuation_roundtrip_empty_key() {
+        let c = ScanContinuation {
+            next_key: String::new(),
+            shard_id_hint: 0,
+        };
+        let bytes = c.encode().unwrap();
+        assert_eq!(ScanContinuation::decode(&bytes).unwrap(), c);
+    }
+
+    #[test]
+    fn scan_continuation_decode_rejects_garbage() {
+        // A short prefix that's nowhere near a valid bincode-serialized
+        // ScanContinuation should be rejected as InvalidArgument.
+        let err = ScanContinuation::decode(b"\xff\xff\xff").unwrap_err();
+        assert!(matches!(err, GgapError::InvalidArgument(_)));
+    }
+}

--- a/proto/ginnungagap/v1/kv.proto
+++ b/proto/ginnungagap/v1/kv.proto
@@ -51,6 +51,9 @@ message ScanRequest {
   string start_key = 1;
   string end_key = 2;
   uint32 limit = 3;
+  // Opaque server-issued cursor. Pass back unmodified to fetch the next
+  // page. Format is not stable across server versions and is NOT a UTF-8
+  // key — clients must treat it as opaque bytes. Empty on the first page.
   bytes page_token = 4;
   ReadConsistency consistency = 5;
 }


### PR DESCRIPTION
## Summary

Extends the `Scan` RPC to support cross-shard iteration with opaque continuation tokens. Clients can now scan across multiple shards without knowing shard boundaries; the service layer handles shard hopping internally while bounding tail latency via a per-RPC hop limit.

## Key Changes

- **`ScanContinuation` token type** (`ggap-types`): New serializable struct encoding the next key and shard hint. Clients pass opaque tokens back to resume pagination. Includes encode/decode via bincode and roundtrip tests.

- **Cross-shard scan logic** (`kv_service.rs`): Rewrote `do_scan` to:
  - Loop up to `MAX_SCAN_HOPS_PER_RPC` (8) times per RPC, advancing cursor across shard boundaries
  - Route each hop by key (not shard ID), so tokens remain valid even after splits
  - Auto-skip empty shards to avoid token ping-pong on sparse keyspaces
  - Respect both per-shard limits and the client's `end_key` across boundaries
  - Emit continuation tokens at shard boundaries or when the limit is hit

- **Router simplification** (`router.rs`): `route_scan` now takes only `start_key` (not `end_key`). Removed the cross-shard validation; the service layer is responsible for bounding each per-shard call to the owning shard's range.

- **`ShardMap` helper** (`shard_map.rs`): Added `next_shard_after(key)` to find the next shard when advancing a cursor. Includes tests for empty map, traversal, and boundary cases.

- **Proto update** (`kv.proto`): Added `page_token` field to `ScanRequest` with documentation.

- **Comprehensive integration tests** (`cross_shard_scan.rs`): New test file with 6 scenarios:
  - Two-shard scan with small limit forcing multiple hops
  - Three shards with empty middle (verifies auto-hop)
  - Leading empty shards (single RPC should surface data)
  - Token validity across intervening splits
  - Invalid token rejection
  - `end_key` enforcement across shard boundaries

- **Test fixture updates** (`split_single_node.rs`): Updated existing tests to use the new single-argument `route_scan` signature.

## Implementation Details

- **Hop budgeting**: `MAX_SCAN_HOPS_PER_RPC = 8` bounds tail latency while still auto-skipping empty shards. If the budget is exhausted with no results, a token is emitted so the client can resume.

- **Token routing**: Tokens encode `next_key` (not shard ID), so they remain correct even if a split commits between RPC calls. The router resolves the actual owning shard on each request.

- **Linearizability**: Cross-shard scans are NOT snapshot-isolated; each per-shard call enforces its own consistency mode. This is acceptable for the current use case.

- **Boundary handling**: `tighter_end` helper ensures the effective scan range respects both the shard's `range.end` and the client's `end_key`.

https://claude.ai/code/session_01VZvJxEtDLmcrue8xjn5dih