### PR TITLE
feat(consensus): cluster-wide shard registry via gossip (#45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-reflection",
  "tower 0.4.13",

--- a/crates/ggap-consensus/src/gossip.rs
+++ b/crates/ggap-consensus/src/gossip.rs
@@ -1,0 +1,269 @@
+//! Background gossip task: periodic push-pull anti-entropy that keeps each
+//! node's [`ShardRegistry`] converged on a cluster-wide view of shard placement
+//! and Raft status.
+//!
+//! Mirrors the [`crate::metrics_task::RaftMetricsTask`] shape (Arc state +
+//! `CancellationToken` + `pub async fn run(self)` with a `tokio::select!`
+//! cancellation guard). All time uses `tokio::time` so the deterministic
+//! simulation harness can pause/advance it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+
+use ggap_proto::v1::{
+    gossip_service_client::GossipServiceClient, GossipNode, GossipShardEntry, GossipState,
+};
+
+use crate::registry::{ShardEntry, ShardRegistry};
+use crate::router::ShardRouter;
+
+const DEFAULT_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_FANOUT: usize = 3;
+const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub struct GossipTask {
+    router: Arc<ShardRouter>,
+    registry: Arc<ShardRegistry>,
+    self_node_id: u64,
+    self_cluster_addr: String,
+    cancel: CancellationToken,
+    interval: Duration,
+    fanout: usize,
+    rpc_timeout: Duration,
+    /// Monotonic heartbeat counter bumped each time we publish local status.
+    version: u64,
+    /// Rotating cursor over the peer list (avoids a `rand` prod dependency).
+    peer_cursor: usize,
+}
+
+impl GossipTask {
+    pub fn new(
+        router: Arc<ShardRouter>,
+        registry: Arc<ShardRegistry>,
+        self_node_id: u64,
+        self_cluster_addr: String,
+        cancel: CancellationToken,
+    ) -> Self {
+        GossipTask {
+            router,
+            registry,
+            self_node_id,
+            self_cluster_addr,
+            cancel,
+            interval: DEFAULT_INTERVAL,
+            fanout: DEFAULT_FANOUT,
+            rpc_timeout: DEFAULT_RPC_TIMEOUT,
+            version: 0,
+            peer_cursor: 0,
+        }
+    }
+
+    pub fn with_interval(mut self, d: Duration) -> Self {
+        self.interval = d;
+        self
+    }
+
+    pub fn with_fanout(mut self, n: usize) -> Self {
+        self.fanout = n;
+        self
+    }
+
+    pub fn with_rpc_timeout(mut self, d: Duration) -> Self {
+        self.rpc_timeout = d;
+        self
+    }
+
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                _ = self.cancel.cancelled() => {
+                    tracing::info!(node_id = self.self_node_id, "gossip task shutting down");
+                    return;
+                }
+                _ = tokio::time::sleep(self.interval) => {}
+            }
+            self.refresh_local().await;
+            self.exchange_round().await;
+        }
+    }
+
+    /// Publish status for every locally-hosted shard into the registry and feed
+    /// the node directory from each shard's Raft membership (transitive peer
+    /// discovery).
+    async fn refresh_local(&mut self) {
+        let shard_ids = self.router.local_shard_ids().await;
+        if shard_ids.is_empty() {
+            return;
+        }
+        self.version += 1;
+
+        // Range/state metadata comes from the shard map (same source the admin
+        // service uses for the authoritative shard list).
+        let shard_meta: HashMap<u64, (String, String, String)> = self
+            .router
+            .shard_map()
+            .all_shards()
+            .await
+            .into_iter()
+            .map(|s| {
+                (
+                    s.shard_id,
+                    (s.range.start, s.range.end, format!("{:?}", s.state)),
+                )
+            })
+            .collect();
+
+        // Seed the directory with self.
+        self.registry
+            .merge_directory([(self.self_node_id, self.self_cluster_addr.clone())])
+            .await;
+
+        for shard_id in shard_ids {
+            let Some(node) = self.router.get_node(shard_id).await else {
+                continue;
+            };
+            let status = node.cluster_status();
+
+            // Each membership pair carries the peer's cluster gRPC address.
+            self.registry
+                .merge_directory(
+                    status
+                        .voters
+                        .iter()
+                        .chain(status.learners.iter())
+                        .map(|(id, addr)| (*id, addr.clone())),
+                )
+                .await;
+
+            let (range_start, range_end, state) = shard_meta
+                .get(&shard_id)
+                .cloned()
+                .unwrap_or_else(|| (String::new(), String::new(), String::new()));
+
+            self.registry
+                .upsert_local(ShardEntry {
+                    shard_id,
+                    range_start,
+                    range_end,
+                    state,
+                    leader_id: status.leader_id,
+                    voters: status.voters.iter().map(|(id, _)| *id).collect(),
+                    learners: status.learners.iter().map(|(id, _)| *id).collect(),
+                    term: status.term,
+                    last_applied: status.last_applied,
+                    version: self.version,
+                    origin_node_id: self.self_node_id,
+                    last_updated: Instant::now(),
+                })
+                .await;
+        }
+    }
+
+    /// Contact up to `fanout` peers (round-robin), push our view and merge
+    /// theirs. Unreachable peers are skipped — their entries simply age.
+    async fn exchange_round(&mut self) {
+        let peers = self.registry.peers_excluding_self().await;
+        if peers.is_empty() {
+            return;
+        }
+
+        let take = self.fanout.min(peers.len());
+        for _ in 0..take {
+            let (peer_id, addr) = peers[self.peer_cursor % peers.len()].clone();
+            self.peer_cursor = self.peer_cursor.wrapping_add(1);
+
+            if addr == self.self_cluster_addr {
+                continue;
+            }
+            if let Err(e) = self.exchange_with(&addr).await {
+                tracing::debug!(node_id = self.self_node_id, peer_id, %addr, error = %e, "gossip exchange failed");
+            }
+        }
+    }
+
+    async fn exchange_with(&self, addr: &str) -> Result<(), String> {
+        let (dir, shards) = self.registry.snapshot_for_gossip().await;
+        let req = GossipState {
+            sender_node_id: self.self_node_id,
+            directory: dir
+                .into_iter()
+                .map(|(node_id, cluster_addr)| GossipNode {
+                    node_id,
+                    cluster_addr,
+                })
+                .collect(),
+            shards: shards.into_iter().map(entry_to_proto).collect(),
+        };
+
+        let endpoint = tonic::transport::Endpoint::from_shared(format!("http://{addr}"))
+            .map_err(|e| e.to_string())?;
+        let channel = tokio::time::timeout(self.rpc_timeout, endpoint.connect())
+            .await
+            .map_err(|_| "connect timed out".to_string())?
+            .map_err(|e| e.to_string())?;
+        let mut client = GossipServiceClient::new(channel);
+
+        let resp = tokio::time::timeout(self.rpc_timeout, client.exchange(req))
+            .await
+            .map_err(|_| "exchange timed out".to_string())?
+            .map_err(|e| e.to_string())?
+            .into_inner();
+
+        merge_gossip_state(&self.registry, resp).await;
+        Ok(())
+    }
+}
+
+/// Merge a received [`GossipState`] (directory + shard entries) into a registry.
+/// Shared by the gossip task (response side) and the gossip service (request
+/// side).
+pub async fn merge_gossip_state(registry: &ShardRegistry, state: GossipState) {
+    registry
+        .merge_directory(
+            state
+                .directory
+                .into_iter()
+                .map(|n| (n.node_id, n.cluster_addr)),
+        )
+        .await;
+    for e in state.shards {
+        registry.merge_entry(entry_from_proto(e)).await;
+    }
+}
+
+pub fn entry_to_proto(e: ShardEntry) -> GossipShardEntry {
+    GossipShardEntry {
+        shard_id: e.shard_id,
+        range_start: e.range_start,
+        range_end: e.range_end,
+        state: e.state,
+        leader_id: e.leader_id,
+        voters: e.voters,
+        learners: e.learners,
+        term: e.term,
+        last_applied: e.last_applied,
+        version: e.version,
+        origin_node_id: e.origin_node_id,
+    }
+}
+
+pub fn entry_from_proto(e: GossipShardEntry) -> ShardEntry {
+    ShardEntry {
+        shard_id: e.shard_id,
+        range_start: e.range_start,
+        range_end: e.range_end,
+        state: e.state,
+        leader_id: e.leader_id,
+        voters: e.voters,
+        learners: e.learners,
+        term: e.term,
+        last_applied: e.last_applied,
+        version: e.version,
+        origin_node_id: e.origin_node_id,
+        // Overwritten by merge_entry to "now"; placeholder here.
+        last_updated: Instant::now(),
+    }
+}

--- a/crates/ggap-consensus/src/lib.rs
+++ b/crates/ggap-consensus/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod config;
 pub mod convert;
+pub mod gossip;
 pub mod log_store;
 pub mod metrics_task;
 pub mod network;
 pub mod node;
+pub mod registry;
 pub mod router;
 pub mod split;
 pub mod state_machine;
@@ -22,10 +24,12 @@ use ggap_types::{
 // ---------------------------------------------------------------------------
 
 pub use config::{build_raft_config, GgapTypeConfig};
+pub use gossip::{merge_gossip_state, GossipTask};
 pub use log_store::GgapLogStorage;
 pub use metrics_task::RaftMetricsTask;
 pub use network::{GgapNetwork, GgapNetworkFactory};
 pub use node::{ClusterNode, ClusterStatus, GgapRaft, LeaseManager, OpenRaftCluster, OpenRaftNode};
+pub use registry::{ShardEntry, ShardRegistry};
 pub use router::ShardRouter;
 pub use split::{run_split_handler, SplitCoordinator, SplitCoordinatorConfig};
 pub use state_machine::{GgapSnapshotBuilder, GgapStateMachine};

--- a/crates/ggap-consensus/src/registry.rs
+++ b/crates/ggap-consensus/src/registry.rs
@@ -1,0 +1,238 @@
+//! In-memory, eventually-consistent view of cluster-wide shard placement and
+//! per-shard Raft status, populated by the gossip task ([`crate::gossip`]).
+//!
+//! The registry is a rebuildable cache — nothing here is persisted. It lets any
+//! node answer `ListShards` / `ClusterStatus` for shards it does not host
+//! locally, degrading gracefully (entries simply age) when a peer is
+//! unreachable. It holds no gRPC types; the proto <-> [`ShardEntry`] conversion
+//! lives in [`crate::gossip`].
+
+use std::collections::HashMap;
+
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+
+use ggap_types::ShardId;
+
+/// One shard's placement + lightweight Raft status as last known to this node.
+///
+/// The hosting set is exactly the Raft membership (`voters` ∪ `learners`); there
+/// is no separate "hosting node ids" — that would be redundant.
+#[derive(Clone, Debug)]
+pub struct ShardEntry {
+    pub shard_id: ShardId,
+    pub range_start: String,
+    pub range_end: String,
+    pub state: String,
+    pub leader_id: Option<u64>,
+    pub voters: Vec<u64>,
+    pub learners: Vec<u64>,
+    pub term: u64,
+    pub last_applied: u64,
+    /// Monotonic heartbeat counter at the origin node.
+    pub version: u64,
+    /// The node that produced this record.
+    pub origin_node_id: u64,
+    /// When *this* node last refreshed the entry — monotonic, pausable for the
+    /// deterministic simulation harness (`tokio::time`, never `std::time`).
+    pub last_updated: Instant,
+}
+
+impl ShardEntry {
+    /// Age of the snapshot from this node's perspective, in milliseconds.
+    pub fn age_ms(&self) -> u64 {
+        self.last_updated.elapsed().as_millis() as u64
+    }
+}
+
+/// The eventually-consistent global view shared between the gossip task, the
+/// gossip service, and the admin service.
+pub struct ShardRegistry {
+    self_node_id: u64,
+    /// `node_id -> cluster_addr`, learned transitively via gossip + bootstrap
+    /// seeds. The address is the cluster gRPC endpoint (shared by RaftService,
+    /// AdminService, and GossipService).
+    directory: RwLock<HashMap<u64, String>>,
+    /// Best-known entry per shard.
+    shards: RwLock<HashMap<ShardId, ShardEntry>>,
+}
+
+impl ShardRegistry {
+    /// Create a registry seeded with an initial `node_id -> cluster_addr`
+    /// directory (typically just `self`).
+    pub fn new(self_node_id: u64, seeds: impl IntoIterator<Item = (u64, String)>) -> Self {
+        ShardRegistry {
+            self_node_id,
+            directory: RwLock::new(seeds.into_iter().collect()),
+            shards: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn self_node_id(&self) -> u64 {
+        self.self_node_id
+    }
+
+    /// Record a shard this node hosts locally. The freshly-built local entry
+    /// always wins (its `last_updated` is now), so local data is never shadowed
+    /// by older gossip about the same shard.
+    pub async fn upsert_local(&self, entry: ShardEntry) {
+        self.shards.write().await.insert(entry.shard_id, entry);
+    }
+
+    /// Merge a gossiped entry using a deterministic, eventual-consistency-safe
+    /// conflict rule: higher term, then higher version, then leader-origin
+    /// authority, then higher last_applied, then higher origin id. On accept,
+    /// `last_updated` is set to now (freshness = when *we* learned it).
+    pub async fn merge_entry(&self, mut incoming: ShardEntry) {
+        incoming.last_updated = Instant::now();
+        let mut shards = self.shards.write().await;
+        match shards.get(&incoming.shard_id) {
+            Some(existing) if !Self::incoming_wins(existing, &incoming) => {}
+            _ => {
+                shards.insert(incoming.shard_id, incoming);
+            }
+        }
+    }
+
+    /// True if `incoming` should replace `existing`.
+    fn incoming_wins(existing: &ShardEntry, incoming: &ShardEntry) -> bool {
+        let existing_leader_origin = existing.leader_id == Some(existing.origin_node_id);
+        let incoming_leader_origin = incoming.leader_id == Some(incoming.origin_node_id);
+        (
+            incoming.term,
+            incoming.version,
+            incoming_leader_origin,
+            incoming.last_applied,
+            incoming.origin_node_id,
+        ) > (
+            existing.term,
+            existing.version,
+            existing_leader_origin,
+            existing.last_applied,
+            existing.origin_node_id,
+        )
+    }
+
+    /// Merge a batch of `node_id -> cluster_addr` directory entries.
+    pub async fn merge_directory(&self, entries: impl IntoIterator<Item = (u64, String)>) {
+        let mut dir = self.directory.write().await;
+        for (node_id, addr) in entries {
+            if addr.is_empty() {
+                continue;
+            }
+            dir.insert(node_id, addr);
+        }
+    }
+
+    /// Cluster address for a node id, if known.
+    pub async fn directory_addr(&self, node_id: u64) -> Option<String> {
+        self.directory.read().await.get(&node_id).cloned()
+    }
+
+    /// Gossip peers: every known node except self, as `(node_id, addr)`.
+    pub async fn peers_excluding_self(&self) -> Vec<(u64, String)> {
+        let mut peers: Vec<(u64, String)> = self
+            .directory
+            .read()
+            .await
+            .iter()
+            .filter(|(id, _)| **id != self.self_node_id)
+            .map(|(id, addr)| (*id, addr.clone()))
+            .collect();
+        // Deterministic order (the gossip task rotates over this).
+        peers.sort_by_key(|(id, _)| *id);
+        peers
+    }
+
+    /// The full view to push to a peer (or return from `Exchange`). Sorted for
+    /// deterministic output.
+    pub async fn snapshot_for_gossip(&self) -> (Vec<(u64, String)>, Vec<ShardEntry>) {
+        let mut dir: Vec<(u64, String)> = self
+            .directory
+            .read()
+            .await
+            .iter()
+            .map(|(id, addr)| (*id, addr.clone()))
+            .collect();
+        dir.sort_by_key(|(id, _)| *id);
+
+        let mut shards: Vec<ShardEntry> = self.shards.read().await.values().cloned().collect();
+        shards.sort_by_key(|e| e.shard_id);
+        (dir, shards)
+    }
+
+    /// Best-known entry for a shard, if any.
+    pub async fn lookup(&self, shard_id: ShardId) -> Option<ShardEntry> {
+        self.shards.read().await.get(&shard_id).cloned()
+    }
+
+    /// All known shard entries, sorted by shard id.
+    pub async fn all(&self) -> Vec<ShardEntry> {
+        let mut shards: Vec<ShardEntry> = self.shards.read().await.values().cloned().collect();
+        shards.sort_by_key(|e| e.shard_id);
+        shards
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(shard_id: ShardId, term: u64, version: u64, origin: u64) -> ShardEntry {
+        ShardEntry {
+            shard_id,
+            range_start: String::new(),
+            range_end: String::new(),
+            state: "Active".into(),
+            leader_id: Some(origin),
+            voters: vec![1, 2, 3],
+            learners: vec![],
+            term,
+            last_applied: 10,
+            version,
+            origin_node_id: origin,
+            last_updated: Instant::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn higher_term_wins() {
+        let reg = ShardRegistry::new(1, []);
+        reg.merge_entry(entry(0, 5, 1, 2)).await;
+        reg.merge_entry(entry(0, 4, 99, 3)).await; // higher version but lower term
+        assert_eq!(reg.lookup(0).await.unwrap().term, 5);
+    }
+
+    #[tokio::test]
+    async fn higher_version_breaks_term_tie() {
+        let reg = ShardRegistry::new(1, []);
+        reg.merge_entry(entry(0, 5, 1, 2)).await;
+        reg.merge_entry(entry(0, 5, 2, 2)).await;
+        assert_eq!(reg.lookup(0).await.unwrap().version, 2);
+    }
+
+    #[tokio::test]
+    async fn local_upsert_present_in_snapshot() {
+        let reg = ShardRegistry::new(1, []);
+        reg.upsert_local(entry(7, 1, 1, 1)).await;
+        let (_, shards) = reg.snapshot_for_gossip().await;
+        assert_eq!(shards.len(), 1);
+        assert_eq!(shards[0].shard_id, 7);
+    }
+
+    #[tokio::test]
+    async fn peers_exclude_self() {
+        let reg = ShardRegistry::new(1, [(1, "a".into()), (2, "b".into()), (3, "c".into())]);
+        let peers = reg.peers_excluding_self().await;
+        assert_eq!(peers, vec![(2, "b".into()), (3, "c".into())]);
+    }
+
+    #[tokio::test]
+    async fn merge_directory_ignores_empty_addr() {
+        let reg = ShardRegistry::new(1, []);
+        reg.merge_directory([(2, String::new()), (3, "c".into())])
+            .await;
+        assert_eq!(reg.directory_addr(2).await, None);
+        assert_eq!(reg.directory_addr(3).await, Some("c".into()));
+    }
+}

--- a/crates/ggap-consensus/src/router.rs
+++ b/crates/ggap-consensus/src/router.rs
@@ -121,4 +121,10 @@ impl ShardRouter {
     pub async fn get_node(&self, shard_id: ShardId) -> Option<Arc<OpenRaftNode>> {
         self.nodes.read().await.get(&shard_id).cloned()
     }
+
+    /// Ids of every shard this node currently hosts (a `RaftNode` is
+    /// registered). Used by the gossip task to publish local shard status.
+    pub async fn local_shard_ids(&self) -> Vec<ShardId> {
+        self.nodes.read().await.keys().copied().collect()
+    }
 }

--- a/crates/ggap-node/src/main.rs
+++ b/crates/ggap-node/src/main.rs
@@ -12,8 +12,8 @@ use serde::Deserialize;
 
 use ggap_consensus::{
     build_raft_config, run_split_handler, GgapLogStorage, GgapNetworkFactory, GgapRaft,
-    GgapStateMachine, OpenRaftCluster, OpenRaftNode, RaftMetricsTask, ShardRouter,
-    SplitCoordinator, SplitCoordinatorConfig,
+    GgapStateMachine, GossipTask, OpenRaftCluster, OpenRaftNode, RaftMetricsTask, ShardRegistry,
+    ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
 use ggap_server::{serve_client, serve_cluster, KvServiceConfig};
 use tokio_util::sync::CancellationToken;
@@ -340,6 +340,24 @@ async fn main() -> anyhow::Result<()> {
         shard_map: shard_map.clone(),
     }));
 
+    // 7b. Cluster-wide shard registry + gossip task. Seeded with self; the node
+    //     directory grows transitively from each shard's Raft membership, so any
+    //     node can report consensus state for shards it does not host locally.
+    let registry = Arc::new(ShardRegistry::new(
+        cli.node_id,
+        [(cli.node_id, cli.cluster_addr.clone())],
+    ));
+    tokio::spawn(
+        GossipTask::new(
+            router.clone(),
+            registry.clone(),
+            cli.node_id,
+            cli.cluster_addr.clone(),
+            shutdown.child_token(),
+        )
+        .run(),
+    );
+
     // 8. Serve with graceful shutdown on SIGINT / SIGTERM.
     let kv_config = KvServiceConfig {
         max_key_bytes: config.storage.max_key_bytes,
@@ -370,7 +388,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::try_join!(
         serve_client(client_addr, router.clone(), cli.node_id, kv_config),
-        serve_cluster(cluster_addr, router, split_coordinator, shard_map),
+        serve_cluster(cluster_addr, router, split_coordinator, shard_map, registry),
     )?;
 
     trace_guard.shutdown();

--- a/crates/ggap-server/Cargo.toml
+++ b/crates/ggap-server/Cargo.toml
@@ -27,6 +27,7 @@ metrics        = { workspace = true }
 ggap-storage = { path = "../ggap-storage" }
 openraft      = { workspace = true }
 tempfile      = { workspace = true }
+tokio-util    = { workspace = true }
 futures       = { workspace = true }
 uuid          = { workspace = true }
 rand          = "0.10"

--- a/crates/ggap-server/benches/kv_write.rs
+++ b/crates/ggap-server/benches/kv_write.rs
@@ -21,7 +21,8 @@ use uuid::Uuid;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
+    OpenRaftCluster, OpenRaftNode, ShardRegistry, ShardRouter, SplitCoordinator,
+    SplitCoordinatorConfig,
 };
 use ggap_proto::v1::{kv_service_client::KvServiceClient, PutRequest};
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener, KvServiceConfig};
@@ -92,11 +93,12 @@ async fn start_node(id: u64) -> BenchNode {
 
     let mut handles = Vec::new();
 
+    let registry = Arc::new(ShardRegistry::new(id, [(id, cluster_addr.to_string())]));
     let r = router.clone();
     let sc = split_coordinator.clone();
     let sm2 = shard_map.clone();
     handles.push(tokio::spawn(async move {
-        if let Err(e) = serve_cluster_with_listener(cluster_listener, r, sc, sm2).await {
+        if let Err(e) = serve_cluster_with_listener(cluster_listener, r, sc, sm2, registry).await {
             eprintln!("node {id} cluster: {e}");
         }
     }));

--- a/crates/ggap-server/src/admin_service.rs
+++ b/crates/ggap-server/src/admin_service.rs
@@ -1,7 +1,7 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use ggap_consensus::{OpenRaftNode, ShardRouter, SplitCoordinator};
+use ggap_consensus::{OpenRaftNode, ShardEntry, ShardRegistry, ShardRouter, SplitCoordinator};
 use ggap_proto::v1::{
     admin_service_server::AdminService, AddLearnerRequest, AddLearnerResponse,
     ChangeMembershipRequest, ChangeMembershipResponse, ClusterStatusRequest, ClusterStatusResponse,
@@ -18,6 +18,9 @@ pub struct AdminServiceImpl {
     router: Arc<ShardRouter>,
     split_coordinator: Arc<SplitCoordinator>,
     shard_map: Arc<ShardMap>,
+    /// Cluster-wide gossiped view, used to answer status for shards this node
+    /// does not host locally.
+    registry: Arc<ShardRegistry>,
 }
 
 impl AdminServiceImpl {
@@ -25,11 +28,13 @@ impl AdminServiceImpl {
         router: Arc<ShardRouter>,
         split_coordinator: Arc<SplitCoordinator>,
         shard_map: Arc<ShardMap>,
+        registry: Arc<ShardRegistry>,
     ) -> Self {
         AdminServiceImpl {
             router,
             split_coordinator,
             shard_map,
+            registry,
         }
     }
 
@@ -45,8 +50,6 @@ impl AdminServiceImpl {
         req: ClusterStatusRequest,
     ) -> Result<Response<ClusterStatusResponse>, Status> {
         let shard_id = req.shard_id.unwrap_or(0);
-        let node = self.node_for_shard(shard_id).await?;
-        let status = node.cluster_status();
 
         let to_node_info = |(node_id, cluster_addr): (u64, String)| NodeInfo {
             node_id,
@@ -54,13 +57,62 @@ impl AdminServiceImpl {
             cluster_addr,
         };
 
-        Ok(Response::new(ClusterStatusResponse {
-            nodes: status.voters.into_iter().map(to_node_info).collect(),
-            leader_id: status.leader_id,
-            term: status.term,
-            last_applied: status.last_applied,
-            learners: status.learners.into_iter().map(to_node_info).collect(),
-        }))
+        // Prefer fresh local openraft metrics when we host the shard.
+        if let Some(node) = self.router.get_node(shard_id).await {
+            let status = node.cluster_status();
+            return Ok(Response::new(ClusterStatusResponse {
+                nodes: status.voters.into_iter().map(to_node_info).collect(),
+                leader_id: status.leader_id,
+                term: status.term,
+                last_applied: status.last_applied,
+                learners: status.learners.into_iter().map(to_node_info).collect(),
+                last_observed_age_ms: Some(0),
+            }));
+        }
+
+        // Otherwise answer from the gossiped registry. A miss is not an error:
+        // return zeroed consensus with `last_observed_age_ms = None` so any
+        // shard is answerable from any node and consumers can tell "no snapshot"
+        // from a real leaderless state.
+        match self.registry.lookup(shard_id).await {
+            Some(entry) => {
+                let age = entry.age_ms();
+                Ok(Response::new(ClusterStatusResponse {
+                    nodes: self.ids_to_node_infos(&entry.voters).await,
+                    leader_id: entry.leader_id,
+                    term: entry.term,
+                    last_applied: entry.last_applied,
+                    learners: self.ids_to_node_infos(&entry.learners).await,
+                    last_observed_age_ms: Some(age),
+                }))
+            }
+            None => Ok(Response::new(ClusterStatusResponse {
+                nodes: vec![],
+                leader_id: None,
+                term: 0,
+                last_applied: 0,
+                learners: vec![],
+                last_observed_age_ms: None,
+            })),
+        }
+    }
+
+    /// Resolve node ids to `NodeInfo`, filling `cluster_addr` from the gossiped
+    /// directory where known (empty otherwise).
+    async fn ids_to_node_infos(&self, ids: &[u64]) -> Vec<NodeInfo> {
+        let mut out = Vec::with_capacity(ids.len());
+        for &node_id in ids {
+            out.push(NodeInfo {
+                node_id,
+                client_addr: String::new(),
+                cluster_addr: self
+                    .registry
+                    .directory_addr(node_id)
+                    .await
+                    .unwrap_or_default(),
+            });
+        }
+        out
     }
 
     async fn do_add_learner(
@@ -164,37 +216,82 @@ impl AdminServiceImpl {
         &self,
         _req: ListShardsRequest,
     ) -> Result<Response<ListShardsResponse>, Status> {
-        let shards = self.shard_map.all_shards().await;
-        let mut protos = Vec::with_capacity(shards.len());
-        for s in shards {
-            let consensus = self
-                .router
-                .get_node(s.shard_id)
-                .await
-                .map(|n| n.cluster_status());
-            let (leader_id, voters, learners, term, last_applied) = match consensus {
-                Some(cs) => (
-                    cs.leader_id,
-                    cs.voters.into_iter().map(|(id, _)| id).collect(),
-                    cs.learners.into_iter().map(|(id, _)| id).collect(),
-                    cs.term,
-                    cs.last_applied,
-                ),
-                None => (None, vec![], vec![], 0, 0),
+        // Authoritative shard list = union of the local shard map and shards we
+        // only know about via gossip. Local shard-map metadata (range/state)
+        // wins where both are present.
+        let mut meta: BTreeMap<u64, (String, String, String)> = BTreeMap::new();
+        for e in self.registry.all().await {
+            meta.entry(e.shard_id)
+                .or_insert((e.range_start, e.range_end, e.state));
+        }
+        for s in self.shard_map.all_shards().await {
+            meta.insert(
+                s.shard_id,
+                (s.range.start, s.range.end, format!("{:?}", s.state)),
+            );
+        }
+
+        let mut protos = Vec::with_capacity(meta.len());
+        for (shard_id, (range_start, range_end, state)) in meta {
+            // Prefer fresh local openraft metrics; fall back to gossip; else
+            // honest zeros with `last_observed_age_ms = None`.
+            let proto = if let Some(node) = self.router.get_node(shard_id).await {
+                let cs = node.cluster_status();
+                ShardInfoProto {
+                    shard_id,
+                    range_start,
+                    range_end,
+                    state,
+                    leader_id: cs.leader_id,
+                    voters: cs.voters.into_iter().map(|(id, _)| id).collect(),
+                    learners: cs.learners.into_iter().map(|(id, _)| id).collect(),
+                    term: cs.term,
+                    last_applied: cs.last_applied,
+                    last_observed_age_ms: Some(0),
+                }
+            } else if let Some(entry) = self.registry.lookup(shard_id).await {
+                entry_to_shard_info(shard_id, range_start, range_end, state, entry)
+            } else {
+                ShardInfoProto {
+                    shard_id,
+                    range_start,
+                    range_end,
+                    state,
+                    leader_id: None,
+                    voters: vec![],
+                    learners: vec![],
+                    term: 0,
+                    last_applied: 0,
+                    last_observed_age_ms: None,
+                }
             };
-            protos.push(ShardInfoProto {
-                shard_id: s.shard_id,
-                range_start: s.range.start,
-                range_end: s.range.end,
-                state: format!("{:?}", s.state),
-                leader_id,
-                voters,
-                learners,
-                term,
-                last_applied,
-            });
+            protos.push(proto);
         }
         Ok(Response::new(ListShardsResponse { shards: protos }))
+    }
+}
+
+/// Build a `ShardInfoProto` from a gossiped registry entry, stamping the
+/// snapshot age so consumers can judge freshness.
+fn entry_to_shard_info(
+    shard_id: u64,
+    range_start: String,
+    range_end: String,
+    state: String,
+    entry: ShardEntry,
+) -> ShardInfoProto {
+    let age = entry.age_ms();
+    ShardInfoProto {
+        shard_id,
+        range_start,
+        range_end,
+        state,
+        leader_id: entry.leader_id,
+        voters: entry.voters,
+        learners: entry.learners,
+        term: entry.term,
+        last_applied: entry.last_applied,
+        last_observed_age_ms: Some(age),
     }
 }
 

--- a/crates/ggap-server/src/gossip_service.rs
+++ b/crates/ggap-server/src/gossip_service.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use ggap_consensus::gossip::entry_to_proto;
+use ggap_consensus::{merge_gossip_state, ShardRegistry};
+use ggap_proto::v1::{gossip_service_server::GossipService, GossipNode, GossipState};
+use tonic::{Request, Response, Status};
+
+use crate::metrics::record;
+
+/// Serves the push-pull anti-entropy `Exchange` RPC: merge the caller's view
+/// into our [`ShardRegistry`], then return our own full view back so both sides
+/// converge. Served on the cluster port alongside RaftService and AdminService.
+pub struct GossipServiceImpl {
+    registry: Arc<ShardRegistry>,
+}
+
+impl GossipServiceImpl {
+    pub fn new(registry: Arc<ShardRegistry>) -> Self {
+        GossipServiceImpl { registry }
+    }
+
+    async fn do_exchange(&self, incoming: GossipState) -> Result<Response<GossipState>, Status> {
+        merge_gossip_state(&self.registry, incoming).await;
+
+        let (dir, shards) = self.registry.snapshot_for_gossip().await;
+        Ok(Response::new(GossipState {
+            sender_node_id: self.registry.self_node_id(),
+            directory: dir
+                .into_iter()
+                .map(|(node_id, cluster_addr)| GossipNode {
+                    node_id,
+                    cluster_addr,
+                })
+                .collect(),
+            shards: shards.into_iter().map(entry_to_proto).collect(),
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl GossipService for GossipServiceImpl {
+    async fn exchange(
+        &self,
+        request: Request<GossipState>,
+    ) -> Result<Response<GossipState>, Status> {
+        let start = tokio::time::Instant::now();
+        let result = self.do_exchange(request.into_inner()).await;
+        record(
+            "ginnungagap.v1.GossipService/Exchange",
+            &result,
+            start.elapsed(),
+        );
+        result
+    }
+}

--- a/crates/ggap-server/src/lib.rs
+++ b/crates/ggap-server/src/lib.rs
@@ -1,5 +1,6 @@
 mod admin_service;
 mod convert;
+mod gossip_service;
 mod kv_service;
 mod metrics;
 mod raft_service;
@@ -11,15 +12,16 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 
-use ggap_consensus::{ShardRouter, SplitCoordinator};
+use ggap_consensus::{ShardRegistry, ShardRouter, SplitCoordinator};
 use ggap_proto::v1::{
-    admin_service_server::AdminServiceServer, kv_service_server::KvServiceServer,
-    raft_service_server::RaftServiceServer,
+    admin_service_server::AdminServiceServer, gossip_service_server::GossipServiceServer,
+    kv_service_server::KvServiceServer, raft_service_server::RaftServiceServer,
 };
 use ggap_storage::ShardMap;
 use tonic_reflection::server::Builder as ReflectionBuilder;
 
 use admin_service::AdminServiceImpl;
+use gossip_service::GossipServiceImpl;
 use kv_service::KvServiceImpl;
 use raft_service::RaftServiceImpl;
 use tracing_layer::OtelServerLayer;
@@ -27,6 +29,10 @@ use tracing_layer::OtelServerLayer;
 // Re-exported so integration tests can construct the service and exercise
 // cross-shard scan hopping without spinning up a real gRPC server.
 pub use kv_service::KvServiceImpl as KvServiceForTesting;
+
+// Re-exported so integration tests can query the admin status RPCs in-process
+// (e.g. to assert gossip-derived consensus state for a non-hosted shard).
+pub use admin_service::AdminServiceImpl as AdminServiceForTesting;
 
 /// Configuration for the client-facing KV service.
 #[derive(Clone, Debug)]
@@ -111,17 +117,24 @@ pub async fn serve_cluster(
     router: Arc<ShardRouter>,
     split_coordinator: Arc<SplitCoordinator>,
     shard_map: Arc<ShardMap>,
+    registry: Arc<ShardRegistry>,
 ) -> anyhow::Result<()> {
     let reflection = ReflectionBuilder::configure()
         .register_encoded_file_descriptor_set(ggap_proto::FILE_DESCRIPTOR_SET)
         .build_v1()
         .expect("failed to build reflection service");
     tracing::info!(%addr, "cluster gRPC server starting");
-    let admin = AdminServiceImpl::new(router.clone(), split_coordinator, shard_map);
+    let admin = AdminServiceImpl::new(
+        router.clone(),
+        split_coordinator,
+        shard_map,
+        registry.clone(),
+    );
     tonic::transport::Server::builder()
         .layer(OtelServerLayer)
         .add_service(RaftServiceServer::new(RaftServiceImpl::new(router)))
         .add_service(AdminServiceServer::new(admin))
+        .add_service(GossipServiceServer::new(GossipServiceImpl::new(registry)))
         .add_service(reflection)
         .serve(addr)
         .await
@@ -134,16 +147,23 @@ pub async fn serve_cluster_with_listener(
     router: Arc<ShardRouter>,
     split_coordinator: Arc<SplitCoordinator>,
     shard_map: Arc<ShardMap>,
+    registry: Arc<ShardRegistry>,
 ) -> anyhow::Result<()> {
     let reflection = ReflectionBuilder::configure()
         .register_encoded_file_descriptor_set(ggap_proto::FILE_DESCRIPTOR_SET)
         .build_v1()
         .expect("failed to build reflection service");
-    let admin = AdminServiceImpl::new(router.clone(), split_coordinator, shard_map);
+    let admin = AdminServiceImpl::new(
+        router.clone(),
+        split_coordinator,
+        shard_map,
+        registry.clone(),
+    );
     tonic::transport::Server::builder()
         .layer(OtelServerLayer)
         .add_service(RaftServiceServer::new(RaftServiceImpl::new(router)))
         .add_service(AdminServiceServer::new(admin))
+        .add_service(GossipServiceServer::new(GossipServiceImpl::new(registry)))
         .add_service(reflection)
         .serve_with_incoming(TcpListenerStream::new(listener))
         .await

--- a/crates/ggap-server/tests/rpc_metrics.rs
+++ b/crates/ggap-server/tests/rpc_metrics.rs
@@ -21,7 +21,8 @@ use tokio::net::TcpListener;
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
+    OpenRaftCluster, OpenRaftNode, ShardRegistry, ShardRouter, SplitCoordinator,
+    SplitCoordinatorConfig,
 };
 use ggap_proto::v1::{
     admin_service_client::AdminServiceClient, kv_service_client::KvServiceClient,
@@ -105,12 +106,13 @@ async fn start_single_node() -> TestNode {
         shard_map: shard_map.clone(),
     }));
 
+    let registry = Arc::new(ShardRegistry::new(1, [(1, cluster_addr.to_string())]));
     let mut handles = Vec::new();
     let r = router.clone();
     let sc = split_coordinator;
     let sm2 = shard_map.clone();
     handles.push(tokio::spawn(async move {
-        let _ = serve_cluster_with_listener(cluster_listener, r, sc, sm2).await;
+        let _ = serve_cluster_with_listener(cluster_listener, r, sc, sm2, registry).await;
     }));
     let r = router.clone();
     handles.push(tokio::spawn(async move {

--- a/crates/ggap-server/tests/three_node_cluster.rs
+++ b/crates/ggap-server/tests/three_node_cluster.rs
@@ -16,17 +16,24 @@ use std::time::Duration;
 use openraft::{BasicNode, ServerState};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
 
 use ggap_consensus::{
     build_raft_config, run_split_handler, GgapLogStorage, GgapNetworkFactory, GgapRaft,
-    GgapStateMachine, OpenRaftCluster, OpenRaftNode, RaftNode, ShardRouter, SplitCoordinator,
-    SplitCoordinatorConfig,
+    GgapStateMachine, GossipTask, OpenRaftCluster, OpenRaftNode, RaftNode, ShardRegistry,
+    ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
 };
-use ggap_server::{serve_client_with_listener, serve_cluster_with_listener, KvServiceConfig};
+use ggap_server::{
+    serve_client_with_listener, serve_cluster_with_listener, AdminServiceForTesting,
+    KvServiceConfig,
+};
 use ggap_storage::fjall::{FjallLogStorage, FjallStateMachine, FjallStore};
 use ggap_storage::traits::StateMachineStore;
 use ggap_storage::ShardMap;
 use ggap_types::{GgapError, KvCommand, KvResponse, ReadMode, WriteMode};
+
+use ggap_proto::v1::admin_service_server::AdminService;
+use ggap_proto::v1::{ClusterStatusRequest, ListShardsRequest, ShardInfoProto};
 
 // ---------------------------------------------------------------------------
 // TestNode — a single in-process Raft node with gRPC servers running
@@ -109,13 +116,30 @@ async fn start_node(id: u64) -> TestNode {
         shard_map: shard_map.clone(),
     }));
 
+    // Cluster registry + fast gossip task (short interval for snappy tests).
+    let registry = Arc::new(ShardRegistry::new(id, [(id, cluster_addr.to_string())]));
+
     let mut handles = Vec::new();
+
+    handles.push(tokio::spawn(
+        GossipTask::new(
+            router.clone(),
+            registry.clone(),
+            id,
+            cluster_addr.to_string(),
+            CancellationToken::new(),
+        )
+        .with_interval(Duration::from_millis(50))
+        .with_rpc_timeout(Duration::from_secs(1))
+        .run(),
+    ));
 
     let r = router.clone();
     let sc = split_coordinator.clone();
     let sm2 = shard_map.clone();
+    let reg = registry.clone();
     handles.push(tokio::spawn(async move {
-        if let Err(e) = serve_cluster_with_listener(cluster_listener, r, sc, sm2).await {
+        if let Err(e) = serve_cluster_with_listener(cluster_listener, r, sc, sm2, reg).await {
             eprintln!("node {id} cluster server: {e}");
         }
     }));
@@ -727,4 +751,216 @@ async fn change_membership_on_follower_returns_not_leader() {
     );
 
     cluster.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// Gossip / shard-registry tests
+// ---------------------------------------------------------------------------
+
+/// A lightweight node that hosts no shard. It runs only a gossip task (dialing
+/// a seed peer) and exposes an in-process AdminService backed by its registry,
+/// so we can assert it learns remote shard status purely via gossip.
+struct Observer {
+    admin: AdminServiceForTesting,
+    handle: tokio::task::JoinHandle<()>,
+    _tempdir: TempDir,
+}
+
+async fn start_observer(id: u64, seed_id: u64, seed_addr: SocketAddr) -> Observer {
+    let tempdir = TempDir::new().unwrap();
+    let store = FjallStore::open(tempdir.path()).unwrap();
+    // No initialize_default: this node's shard map is empty, so any shard it
+    // reports must have been learned via gossip.
+    let shard_map = Arc::new(ShardMap::load(store).unwrap());
+    let router = Arc::new(ShardRouter::new(shard_map.clone()));
+    let split_coordinator = Arc::new(SplitCoordinator::new(SplitCoordinatorConfig {
+        router: router.clone(),
+        shard_map: shard_map.clone(),
+    }));
+    // Self addr is a dummy (the observer serves nothing and never dials itself);
+    // the seed gives it an entry point into the cluster's gossip directory.
+    let self_addr = format!("127.0.0.1:1{id}");
+    let registry = Arc::new(ShardRegistry::new(
+        id,
+        [(id, self_addr.clone()), (seed_id, seed_addr.to_string())],
+    ));
+    let handle = tokio::spawn(
+        GossipTask::new(
+            router.clone(),
+            registry.clone(),
+            id,
+            self_addr,
+            CancellationToken::new(),
+        )
+        .with_interval(Duration::from_millis(50))
+        .with_rpc_timeout(Duration::from_secs(1))
+        .run(),
+    );
+    let admin = AdminServiceForTesting::new(router, split_coordinator, shard_map, registry);
+    Observer {
+        admin,
+        handle,
+        _tempdir: tempdir,
+    }
+}
+
+async fn list_shard(admin: &AdminServiceForTesting, shard_id: u64) -> Option<ShardInfoProto> {
+    let resp = admin
+        .list_shards(tonic::Request::new(ListShardsRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+    resp.shards.into_iter().find(|s| s.shard_id == shard_id)
+}
+
+/// A node that does not host a shard can still report that shard's correct
+/// consensus state once gossip converges, and reports an explicit "no snapshot"
+/// marker (age = None) for a shard it has never heard of — distinct from a real
+/// leaderless/zero state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gossip_reports_remote_shard_status_from_non_hosting_node() {
+    let cluster = TestCluster::start(3).await;
+    let leader_idx = cluster.wait_for_leader().await;
+    let leader = &cluster.nodes[leader_idx];
+
+    // A write so last_applied > 0 and there is real consensus state to gossip.
+    let resp = leader
+        .raft
+        .client_write(KvCommand::Put {
+            key: "k".into(),
+            value: b"v".to_vec(),
+            ttl_ns: None,
+            expect_version: 0,
+        })
+        .await
+        .unwrap();
+    cluster.wait_for_all_applied(resp.log_id().index).await;
+    let expected = leader.raft_node.cluster_status();
+
+    // Observer hosts no shard; seed it with the leader's cluster address.
+    let observer = start_observer(99, leader.id, leader.cluster_addr).await;
+
+    // Poll until the observer has learned shard 0 via gossip.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let info = loop {
+        if let Some(info) = list_shard(&observer.admin, 0).await {
+            if info.leader_id.is_some() && info.last_applied >= expected.last_applied {
+                break info;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "observer did not learn shard 0 via gossip"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    assert_eq!(
+        info.leader_id,
+        Some(leader.id),
+        "observer should see the real leader"
+    );
+    assert_eq!(
+        info.term, expected.term,
+        "observer should see the real term"
+    );
+    let voters: BTreeSet<u64> = info.voters.iter().copied().collect();
+    assert_eq!(
+        voters,
+        BTreeSet::from([1, 2, 3]),
+        "observer should see all voters"
+    );
+    // Remote data carries a real (gossip-derived) age, not "no snapshot".
+    assert!(
+        info.last_observed_age_ms.is_some(),
+        "remote shard must carry a snapshot age"
+    );
+
+    // ClusterStatus for the remote shard also works (not NotFound).
+    let cs = observer
+        .admin
+        .cluster_status(tonic::Request::new(ClusterStatusRequest {
+            shard_id: Some(0),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(cs.leader_id, Some(leader.id));
+    assert!(cs.last_observed_age_ms.is_some());
+
+    // A shard the observer has never heard of: honest zeros + age = None,
+    // distinguishable from a genuinely leaderless shard (which would carry an age).
+    let unknown = observer
+        .admin
+        .cluster_status(tonic::Request::new(ClusterStatusRequest {
+            shard_id: Some(12345),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(unknown.leader_id, None);
+    assert_eq!(unknown.term, 0);
+    assert_eq!(
+        unknown.last_observed_age_ms, None,
+        "unknown shard must be distinguishable from leaderless"
+    );
+
+    observer.handle.abort();
+    cluster.shutdown().await;
+}
+
+/// When every host of a shard becomes unreachable, a non-hosting node keeps
+/// answering with the last-known consensus state and a growing age, rather than
+/// failing the RPC.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn gossip_degrades_to_stale_when_hosts_unreachable() {
+    let cluster = TestCluster::start(3).await;
+    let leader_idx = cluster.wait_for_leader().await;
+    let leader_id = cluster.nodes[leader_idx].id;
+    let leader_addr = cluster.nodes[leader_idx].cluster_addr;
+
+    let observer = start_observer(99, leader_id, leader_addr).await;
+
+    // Converge first.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(info) = list_shard(&observer.admin, 0).await {
+            if info.last_observed_age_ms.is_some() && info.leader_id.is_some() {
+                break;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "observer never converged on shard 0"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Take the whole cluster down — no host remains reachable.
+    cluster.shutdown().await;
+
+    // The observer must keep answering (Ok) with a growing age rather than
+    // failing the RPC, and must not fabricate fresh state.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let info = list_shard(&observer.admin, 0)
+            .await
+            .expect("shard 0 should still be listed after hosts go down");
+        assert!(
+            info.last_observed_age_ms.is_some(),
+            "stale entry should still carry an age"
+        );
+        if info.last_observed_age_ms.unwrap() >= 500 {
+            // Still reports the last-known leader (stale, not fabricated/zeroed).
+            assert_eq!(info.leader_id, Some(leader_id));
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "snapshot age never grew after all hosts went down"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    observer.handle.abort();
 }

--- a/crates/ggap-server/tests/trace_propagation.rs
+++ b/crates/ggap-server/tests/trace_propagation.rs
@@ -31,7 +31,8 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use ggap_consensus::{
     build_raft_config, GgapLogStorage, GgapNetworkFactory, GgapRaft, GgapStateMachine,
-    OpenRaftCluster, OpenRaftNode, ShardRouter, SplitCoordinator, SplitCoordinatorConfig,
+    OpenRaftCluster, OpenRaftNode, ShardRegistry, ShardRouter, SplitCoordinator,
+    SplitCoordinatorConfig,
 };
 use ggap_proto::v1::{kv_service_client::KvServiceClient, GetRequest, PutRequest};
 use ggap_server::{serve_client_with_listener, serve_cluster_with_listener, KvServiceConfig};
@@ -133,12 +134,13 @@ async fn start_single_node() -> TestNode {
         shard_map: shard_map.clone(),
     }));
 
+    let registry = Arc::new(ShardRegistry::new(1, [(1, cluster_addr.to_string())]));
     let mut handles = Vec::new();
     let r = router.clone();
     let sc = split_coordinator;
     let sm2 = shard_map.clone();
     handles.push(tokio::spawn(async move {
-        let _ = serve_cluster_with_listener(cluster_listener, r, sc, sm2).await;
+        let _ = serve_cluster_with_listener(cluster_listener, r, sc, sm2, registry).await;
     }));
     let r2 = router.clone();
     handles.push(tokio::spawn(async move {

--- a/proto/ginnungagap/v1/cluster.proto
+++ b/proto/ginnungagap/v1/cluster.proto
@@ -18,6 +18,15 @@ service AdminService {
   rpc ListShards       (ListShardsRequest)        returns (ListShardsResponse);
 }
 
+// Cluster-wide shard placement/status gossip. Served on the cluster port
+// alongside RaftService and AdminService. Push-pull anti-entropy: a node sends
+// its known view (node directory + per-shard status), the responder merges it
+// and returns its own full view, so every node converges on a coherent
+// (eventually-consistent) global picture without on-demand fan-out.
+service GossipService {
+  rpc Exchange (GossipState) returns (GossipState);
+}
+
 message RaftMessage {
   uint64 shard_id = 1;
   bytes data = 2;
@@ -34,6 +43,12 @@ message ClusterStatusResponse {
   uint64 term = 3;
   uint64 last_applied = 4;
   repeated NodeInfo learners = 5;
+  // Age (ms) of the consensus snapshot from the responding node's view.
+  // 0 means the responder hosts the shard locally (read live). A large value
+  // means the snapshot was learned via gossip and may be stale. Unset means the
+  // shard is known to exist but no consensus snapshot has been observed yet
+  // (distinguishes "no data" from a genuinely leaderless shard).
+  optional uint64 last_observed_age_ms = 6;
 }
 
 message AddLearnerRequest {
@@ -78,14 +93,54 @@ message ShardInfoProto {
   string range_start = 2;
   string range_end = 3;
   string state = 4;
-  // Raft consensus fields — populated when the node hosts this shard locally.
+  // Raft consensus fields. Populated from local openraft metrics when this node
+  // hosts the shard, otherwise from the gossiped shard registry. See
+  // last_observed_age_ms for provenance/freshness.
   optional uint64 leader_id = 5;
   repeated uint64 voters = 6;
   repeated uint64 learners = 7;
   uint64 term = 8;
   uint64 last_applied = 9;
+  // Age (ms) of the consensus snapshot. 0 = hosted locally (live). Larger =
+  // learned via gossip (older = host likely unreachable). Unset = no snapshot
+  // observed yet, so the consensus fields above are absent-of-data, not real
+  // "leaderless / term 0" state.
+  optional uint64 last_observed_age_ms = 10;
 }
 
 message ListShardsResponse {
   repeated ShardInfoProto shards = 1;
+}
+
+// One node's identity plus reachable cluster gRPC address, for transitive peer
+// discovery: a node learns about peers it doesn't directly co-host a shard with
+// by receiving their directory entries through gossip.
+message GossipNode {
+  uint64 node_id = 1;
+  string cluster_addr = 2;
+}
+
+// One shard's placement + lightweight Raft status as known by some origin node.
+// The hosting set is exactly the Raft membership (voters ∪ learners); there is
+// no separate "hosting_node_ids".
+message GossipShardEntry {
+  uint64 shard_id = 1;
+  string range_start = 2;
+  string range_end = 3;
+  string state = 4;
+  optional uint64 leader_id = 5;
+  repeated uint64 voters = 6;
+  repeated uint64 learners = 7;
+  uint64 term = 8;
+  uint64 last_applied = 9;
+  // Conflict-resolution metadata: version is a monotonic heartbeat counter at
+  // the origin node; origin_node_id is the node that produced this record.
+  uint64 version = 10;
+  uint64 origin_node_id = 11;
+}
+
+message GossipState {
+  uint64 sender_node_id = 1;
+  repeated GossipNode directory = 2;
+  repeated GossipShardEntry shards = 3;
 }


### PR DESCRIPTION
AdminService status RPCs (ListShards, ClusterStatus) could only report Raft
consensus state for shards the receiving node hosted locally; non-hosted shards
were zeroed out (ListShards) or returned NotFound (ClusterStatus), so a consumer
could not tell "not hosted here" from "leaderless".

Add a background gossip / shard-registry subsystem so any node can answer status
for every shard in the cluster, degrading gracefully when a peer is unreachable:

- ShardRegistry (ggap-consensus): in-memory, eventually-consistent view of shard
  placement + per-shard Raft status with deterministic conflict resolution
  (term > version > leader-origin > last_applied > origin). Rebuildable cache,
  nothing persisted; gRPC-free.
- GossipTask (ggap-consensus): periodic push-pull anti-entropy that publishes
  local shard status, discovers peers transitively from Raft membership
  addresses, and merges peer views. tokio::time only (pausable for sim); per-peer
  timeout; round-robin peer selection; never dials self.
- GossipService (proto + ggap-server): Exchange RPC served on the cluster port
  alongside RaftService/AdminService.
- AdminService now answers from local openraft metrics when hosting a shard, else
  from the gossiped registry, with an honest last_observed_age_ms recency signal:
  0 = hosted/live, larger = gossiped (host likely down), unset = no snapshot yet
  (distinct from a real leaderless state). The shard list is the union of the
  local shard map and gossiped entries. ClusterStatus for an unknown shard now
  returns honest zeros instead of NotFound.

Hosting set == Raft membership (voters ∪ learners); no redundant hosting list.

Tests: multi-node integration coverage for a non-hosting node reporting a remote
shard's correct consensus state after gossip converges, peer-down degrading to a
growing age (never a whole-RPC failure), and the unknown-shard "no snapshot"
marker; plus registry conflict-resolution unit tests.

https://claude.ai/code/session_011BepNnjemjjktqodfc8cJ3